### PR TITLE
Add server entity and application DB context

### DIFF
--- a/CloudCityCenter/Data/ApplicationDbContext.cs
+++ b/CloudCityCenter/Data/ApplicationDbContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using CloudCityCenter.Models;
+
+namespace CloudCityCenter.Data;
+
+public class ApplicationDbContext : IdentityDbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Server> Servers { get; set; } = null!;
+}
+

--- a/CloudCityCenter/Models/Server.cs
+++ b/CloudCityCenter/Models/Server.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CloudCityCenter.Models;
+
+public class Server
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100)]
+    public string Location { get; set; } = string.Empty;
+
+    [Required]
+    [Range(0, double.MaxValue)]
+    public decimal PricePerMonth { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string Configuration { get; set; } = string.Empty;
+
+    public bool IsAvailable { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `Server` model with validation attributes
- add `ApplicationDbContext` derived from `IdentityDbContext`

## Testing
- `dotnet build CloudCityCenter/CloudCityCenter.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd9ce0f0832ba734c7d6d83b9a08