### PR TITLE
Add database connection string to appsettings

### DIFF
--- a/CloudCityCenter/appsettings.Development.json
+++ b/CloudCityCenter/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=CloudCityDb;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 }

--- a/CloudCityCenter/appsettings.json
+++ b/CloudCityCenter/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=CloudCityDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- update configuration with a `DefaultConnection` string

## Testing
- `dotnet build CloudCityCenter/CloudCityCenter.csproj -c Release` *(fails: Microsoft.AspNetCore.Identity.EntityFrameworkCore 9.0.6 is not compatible with net8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6852e4c2476c832bbe804e3eaa8baa9a