### PR TITLE
Add default connection strings

### DIFF
--- a/CloudCityCenter/appsettings.Development.json
+++ b/CloudCityCenter/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=CloudCityCenterDb;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 }

--- a/CloudCityCenter/appsettings.json
+++ b/CloudCityCenter/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=CloudCityCenterDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- add `ConnectionStrings` section to production and development settings for database connection

## Testing
- `python3 -m json.tool CloudCityCenter/appsettings.json`
- `python3 -m json.tool CloudCityCenter/appsettings.Development.json`


------
https://chatgpt.com/codex/tasks/task_e_6852efddb110832ba9e194c30fd563df