### PR TITLE
Use CDN for Bootstrap and jQuery

### DIFF
--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - CloudCityCenter</title>
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/CloudCityCenter.styles.css" asp-append-version="true" />
 </head>
@@ -41,8 +41,8 @@
             &copy; 2025 - CloudCityCenter - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
         </div>
     </footer>
-    <script src="~/lib/jquery/dist/jquery.min.js"></script>
-    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ git clone https://github.com/yourusername/CloudCityCenter.git
 3. Убедиться, что настроена строка подключения к SQL Server.
 4. Запустить `Update-Database` через Package Manager Console.
 5. Запустить проект (F5).
+
+## 📚 Frontend библиотеки
+
+Bootstrap и jQuery подключены через CDN в файле `_Layout.cshtml`. Локальная папка `wwwroot/lib` не используется.


### PR DESCRIPTION
## Summary
- load Bootstrap and jQuery from CDN instead of nonexistent local libs
- mention CDN approach in README

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f0777e68832b812762f2d3ab467f