### PR TITLE
Update validation scripts partial to use CDN

### DIFF
--- a/CloudCityCenter/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/CloudCityCenter/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,2 +1,2 @@
-﻿<script src="~/lib/jquery-validation/dist/jquery.validate.min.js"></script>
-<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"></script>
+﻿<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.5/jquery.validate.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.12/jquery.validate.unobtrusive.min.js"></script>


### PR DESCRIPTION
## Summary
- switch jQuery validation scripts to CDN links in `_ValidationScriptsPartial.cshtml`

## Testing
- `dotnet test CloudCityCenter.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f6405224832b8db93ecf2c4d82c8