### PR TITLE
Add Servers link in layout

### DIFF
--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -23,6 +23,9 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Servers" asp-action="Index">Servers</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary
- add Servers menu link in site layout

## Testing
- `dotnet restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ff7357d0832bbfde99686fc0f06c