### PR TITLE
Fix server headers for empty list

### DIFF
--- a/CloudCityCenter/Views/Servers/Index.cshtml
+++ b/CloudCityCenter/Views/Servers/Index.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewData["Title"] = "Servers";
+    var dummy = new CloudCityCenter.Models.Server();
 }
 
 <h1>Servers</h1>
@@ -13,19 +14,19 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(model => model.First().Name)
+                @Html.DisplayNameFor(model => dummy.Name)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.First().Location)
+                @Html.DisplayNameFor(model => dummy.Location)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.First().PricePerMonth)
+                @Html.DisplayNameFor(model => dummy.PricePerMonth)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.First().Configuration)
+                @Html.DisplayNameFor(model => dummy.Configuration)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.First().IsAvailable)
+                @Html.DisplayNameFor(model => dummy.IsAvailable)
             </th>
             <th></th>
         </tr>


### PR DESCRIPTION
## Summary
- avoid referencing `model.First()` when rendering server table headers
- add dummy `Server` instance to generate display names safely

## Testing
- `dotnet build CloudCityCenter.sln`
- `dotnet test CloudCityCenter.Tests/CloudCityCenter.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6852ffef2374832b845963f93c61f09b