### PR TITLE
Add ServersController unit tests

### DIFF
--- a/CloudCityCenter.Tests/CloudCityCenter.Tests.csproj
+++ b/CloudCityCenter.Tests/CloudCityCenter.Tests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CloudCityCenter.Tests/ServersControllerTests.cs
+++ b/CloudCityCenter.Tests/ServersControllerTests.cs
@@ -1,0 +1,70 @@
+using CloudCityCenter.Controllers;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace CloudCityCenter.Tests;
+
+public class ServersControllerTests
+{
+    private static ApplicationDbContext GetInMemoryDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        var context = new ApplicationDbContext(options);
+        return context;
+    }
+
+    [Fact]
+    public async Task Index_ReturnsViewResult_WithListOfServers()
+    {
+        // Arrange
+        var context = GetInMemoryDbContext(nameof(Index_ReturnsViewResult_WithListOfServers));
+        context.Servers.AddRange(
+            new Server { Id = 1, Name = "Server1", Location = "US", PricePerMonth = 10, Configuration = "Conf1", IsAvailable = true },
+            new Server { Id = 2, Name = "Server2", Location = "EU", PricePerMonth = 20, Configuration = "Conf2", IsAvailable = true }
+        );
+        await context.SaveChangesAsync();
+        var controller = new ServersController(context);
+
+        // Act
+        var result = await controller.Index();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsAssignableFrom<List<Server>>(viewResult.Model);
+        Assert.Equal(2, model.Count);
+    }
+
+    [Fact]
+    public async Task Details_ReturnsNotFound_WhenIdIsNull()
+    {
+        // Arrange
+        var context = GetInMemoryDbContext(nameof(Details_ReturnsNotFound_WhenIdIsNull));
+        var controller = new ServersController(context);
+
+        // Act
+        var result = await controller.Details(null);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Details_ReturnsNotFound_WhenServerDoesNotExist()
+    {
+        // Arrange
+        var context = GetInMemoryDbContext(nameof(Details_ReturnsNotFound_WhenServerDoesNotExist));
+        context.Servers.Add(new Server { Id = 1, Name = "Server1", Location = "US", PricePerMonth = 10, Configuration = "Conf1", IsAvailable = true });
+        await context.SaveChangesAsync();
+        var controller = new ServersController(context);
+
+        // Act
+        var result = await controller.Details(2);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+}


### PR DESCRIPTION
## Summary
- test servers controller with in-memory ApplicationDbContext
- check that index returns the list of servers
- verify details returns not found for invalid ids
- use EF Core InMemory provider for tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685301fec594832b87c49fdf2c368463