### PR TITLE
Add Orders CRUD and tests

### DIFF
--- a/CloudCityCenter.Tests/OrdersControllerTests.cs
+++ b/CloudCityCenter.Tests/OrdersControllerTests.cs
@@ -1,0 +1,62 @@
+using System.Security.Claims;
+using CloudCityCenter.Controllers;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace CloudCityCenter.Tests;
+
+public class OrdersControllerTests
+{
+    private static ApplicationDbContext GetInMemoryDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static OrdersController GetController(ApplicationDbContext context, string userId)
+    {
+        var controller = new OrdersController(context);
+        var user = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, userId) }, "Test"));
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = user } };
+        return controller;
+    }
+
+    [Fact]
+    public async Task Index_ReturnsOrdersForCurrentUser()
+    {
+        var context = GetInMemoryDbContext(nameof(Index_ReturnsOrdersForCurrentUser));
+        context.Servers.Add(new Server { Id = 1, Name = "S1", Location = "L", PricePerMonth = 1, Configuration = "C", IsAvailable = true });
+        context.Orders.AddRange(
+            new Order { Id = 1, UserId = "user1", ServerId = 1, TotalPrice = 5 },
+            new Order { Id = 2, UserId = "user2", ServerId = 1, TotalPrice = 6 }
+        );
+        await context.SaveChangesAsync();
+        var controller = GetController(context, "user1");
+
+        var result = await controller.Index();
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsAssignableFrom<List<Order>>(viewResult.Model);
+        Assert.Single(model);
+        Assert.Equal(1, model[0].Id);
+    }
+
+    [Fact]
+    public async Task Details_ReturnsNotFound_WhenOrderDoesNotExist()
+    {
+        var context = GetInMemoryDbContext(nameof(Details_ReturnsNotFound_WhenOrderDoesNotExist));
+        context.Servers.Add(new Server { Id = 1, Name = "S1", Location = "L", PricePerMonth = 1, Configuration = "C", IsAvailable = true });
+        context.Orders.Add(new Order { Id = 1, UserId = "user1", ServerId = 1, TotalPrice = 5 });
+        await context.SaveChangesAsync();
+        var controller = GetController(context, "user1");
+
+        var result = await controller.Details(2);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/CloudCityCenter/Controllers/OrdersController.cs
+++ b/CloudCityCenter/Controllers/OrdersController.cs
@@ -1,0 +1,173 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+
+namespace CloudCityCenter.Controllers;
+
+public class OrdersController : Controller
+{
+    private readonly ApplicationDbContext _context;
+
+    public OrdersController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    // GET: Orders
+    public async Task<IActionResult> Index()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var orders = await _context.Orders
+            .Include(o => o.Server)
+            .Where(o => o.UserId == userId)
+            .ToListAsync();
+        return View(orders);
+    }
+
+    // GET: Orders/Details/5
+    public async Task<IActionResult> Details(int? id)
+    {
+        if (id == null)
+        {
+            return NotFound();
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var order = await _context.Orders
+            .Include(o => o.Server)
+            .FirstOrDefaultAsync(m => m.Id == id && m.UserId == userId);
+        if (order == null)
+        {
+            return NotFound();
+        }
+
+        return View(order);
+    }
+
+    // GET: Orders/Create
+    public IActionResult Create()
+    {
+        ViewData["ServerId"] = new Microsoft.AspNetCore.Mvc.Rendering.SelectList(_context.Servers, "Id", "Name");
+        return View();
+    }
+
+    // POST: Orders/Create
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create([Bind("ServerId,TotalPrice")] Order order)
+    {
+        order.UserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
+        order.OrderDate = DateTime.UtcNow;
+        if (ModelState.IsValid)
+        {
+            _context.Add(order);
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+        ViewData["ServerId"] = new Microsoft.AspNetCore.Mvc.Rendering.SelectList(_context.Servers, "Id", "Name", order.ServerId);
+        return View(order);
+    }
+
+    // GET: Orders/Edit/5
+    public async Task<IActionResult> Edit(int? id)
+    {
+        if (id == null)
+        {
+            return NotFound();
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var order = await _context.Orders.FindAsync(id);
+        if (order == null || order.UserId != userId)
+        {
+            return NotFound();
+        }
+        ViewData["ServerId"] = new Microsoft.AspNetCore.Mvc.Rendering.SelectList(_context.Servers, "Id", "Name", order.ServerId);
+        return View(order);
+    }
+
+    // POST: Orders/Edit/5
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(int id, [Bind("Id,ServerId,TotalPrice")] Order order)
+    {
+        if (id != order.Id)
+        {
+            return NotFound();
+        }
+
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var existing = await _context.Orders.AsNoTracking().FirstOrDefaultAsync(o => o.Id == id && o.UserId == userId);
+        if (existing == null)
+        {
+            return NotFound();
+        }
+
+        if (ModelState.IsValid)
+        {
+            try
+            {
+                order.UserId = existing.UserId;
+                order.OrderDate = existing.OrderDate;
+                _context.Update(order);
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!OrderExists(order.Id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+            return RedirectToAction(nameof(Index));
+        }
+        ViewData["ServerId"] = new Microsoft.AspNetCore.Mvc.Rendering.SelectList(_context.Servers, "Id", "Name", order.ServerId);
+        return View(order);
+    }
+
+    // GET: Orders/Delete/5
+    public async Task<IActionResult> Delete(int? id)
+    {
+        if (id == null)
+        {
+            return NotFound();
+        }
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var order = await _context.Orders
+            .Include(o => o.Server)
+            .FirstOrDefaultAsync(m => m.Id == id && m.UserId == userId);
+        if (order == null)
+        {
+            return NotFound();
+        }
+
+        return View(order);
+    }
+
+    // POST: Orders/Delete/5
+    [HttpPost, ActionName("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteConfirmed(int id)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var order = await _context.Orders.FirstOrDefaultAsync(o => o.Id == id && o.UserId == userId);
+        if (order != null)
+        {
+            _context.Orders.Remove(order);
+            await _context.SaveChangesAsync();
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
+    private bool OrderExists(int id)
+    {
+        return _context.Orders.Any(e => e.Id == id);
+    }
+}
+

--- a/CloudCityCenter/Views/Orders/Create.cshtml
+++ b/CloudCityCenter/Views/Orders/Create.cshtml
@@ -1,0 +1,33 @@
+@model CloudCityCenter.Models.Order
+
+@{
+    ViewData["Title"] = "Create";
+}
+
+<h1>Create</h1>
+
+<h4>Order</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="mb-3">
+                <label asp-for="ServerId" class="form-label"></label>
+                <select asp-for="ServerId" class="form-select" asp-items="ViewBag.ServerId"></select>
+                <span asp-validation-for="ServerId" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="TotalPrice" class="form-label"></label>
+                <input asp-for="TotalPrice" class="form-control" />
+                <span asp-validation-for="TotalPrice" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-primary">Create</button>
+            <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/CloudCityCenter/Views/Orders/Delete.cshtml
+++ b/CloudCityCenter/Views/Orders/Delete.cshtml
@@ -1,0 +1,27 @@
+@model CloudCityCenter.Models.Order
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<h1>Delete</h1>
+
+<h4>Are you sure you want to delete this?</h4>
+<div>
+    <h4>Order</h4>
+    <hr />
+    <dl class="row">
+        <dt class="col-sm-2">Server</dt>
+        <dd class="col-sm-10">@Model.Server?.Name</dd>
+        <dt class="col-sm-2">Order Date</dt>
+        <dd class="col-sm-10">@Model.OrderDate</dd>
+        <dt class="col-sm-2">Total Price</dt>
+        <dd class="col-sm-10">@Model.TotalPrice</dd>
+    </dl>
+
+    <form asp-action="Delete" method="post">
+        <input type="hidden" asp-for="Id" />
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+    </form>
+</div>

--- a/CloudCityCenter/Views/Orders/Details.cshtml
+++ b/CloudCityCenter/Views/Orders/Details.cshtml
@@ -1,0 +1,24 @@
+@model CloudCityCenter.Models.Order
+
+@{
+    ViewData["Title"] = "Details";
+}
+
+<h1>Details</h1>
+
+<div>
+    <h4>Order</h4>
+    <hr />
+    <dl class="row">
+        <dt class="col-sm-2">Server</dt>
+        <dd class="col-sm-10">@Model.Server?.Name</dd>
+        <dt class="col-sm-2">Order Date</dt>
+        <dd class="col-sm-10">@Model.OrderDate</dd>
+        <dt class="col-sm-2">Total Price</dt>
+        <dd class="col-sm-10">@Model.TotalPrice</dd>
+    </dl>
+</div>
+<div>
+    <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a> |
+    <a asp-action="Index">Back to List</a>
+</div>

--- a/CloudCityCenter/Views/Orders/Edit.cshtml
+++ b/CloudCityCenter/Views/Orders/Edit.cshtml
@@ -1,0 +1,34 @@
+@model CloudCityCenter.Models.Order
+
+@{
+    ViewData["Title"] = "Edit";
+}
+
+<h1>Edit</h1>
+
+<h4>Order</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Edit">
+            <input type="hidden" asp-for="Id" />
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="mb-3">
+                <label asp-for="ServerId" class="form-label"></label>
+                <select asp-for="ServerId" class="form-select" asp-items="ViewBag.ServerId"></select>
+                <span asp-validation-for="ServerId" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="TotalPrice" class="form-label"></label>
+                <input asp-for="TotalPrice" class="form-control" />
+                <span asp-validation-for="TotalPrice" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-primary">Save</button>
+            <a asp-action="Index" class="btn btn-secondary">Back to List</a>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/CloudCityCenter/Views/Orders/Index.cshtml
+++ b/CloudCityCenter/Views/Orders/Index.cshtml
@@ -1,0 +1,36 @@
+@model IEnumerable<CloudCityCenter.Models.Order>
+
+@{
+    ViewData["Title"] = "Orders";
+}
+
+<h1>Orders</h1>
+
+<p>
+    <a asp-action="Create" class="btn btn-primary">Create New</a>
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Server</th>
+            <th>Order Date</th>
+            <th>Total Price</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model)
+{
+        <tr>
+            <td>@item.Server?.Name</td>
+            <td>@item.OrderDate</td>
+            <td>@item.TotalPrice</td>
+            <td>
+                <a asp-action="Edit" asp-route-id="@item.Id">Edit</a> |
+                <a asp-action="Details" asp-route-id="@item.Id">Details</a> |
+                <a asp-action="Delete" asp-route-id="@item.Id">Delete</a>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -26,6 +26,9 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Servers" asp-action="Index">Servers</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Orders" asp-action="Index">Orders</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                     </ul>


### PR DESCRIPTION
## Summary
- scaffold OrdersController with CRUD actions that tie orders to logged in user
- create Orders Razor views
- link Orders to the site navigation
- add unit tests for OrdersController

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853085cbb78832b94acc351c97414bd