### PR TITLE
Update connection string setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,18 @@ dotnet test
 ```bash
 dotnet run --project CloudCityCenter -- seed
 ```
+
+## 🔗 Изменение строки подключения
+
+Строка подключения `DefaultConnection` по умолчанию указывает на LocalDB. Вы можете отредактировать её в файле `CloudCityCenter/appsettings.json` или передать значение через переменную окружения:
+
+```bash
+export ConnectionStrings__DefaultConnection="Server=...;Database=...;Trusted_Connection=True;"
+```
+
+После изменения строки подключения примените миграции и, при необходимости, заполните базу примерами:
+
+```bash
+dotnet ef database update
+dotnet run --project CloudCityCenter -- seed
+```


### PR DESCRIPTION
## Summary
- document how to override `DefaultConnection`

## Testing
- `dotnet test CloudCityCenter.Tests/CloudCityCenter.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531ef32180832bbd7084559952ff5c