### PR TITLE
Remove sample images and ignore folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ artifacts/
 wwwroot/lib/
 node_modules/
 bower_components/
+CloudCityCenter/wwwroot/images/*
 
 ## OS generated
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ dotnet run --project CloudCityCenter -- seed
 dotnet run --project CloudCityCenter
 ```
 
+После запуска поместите нужные изображения в папку `CloudCityCenter/wwwroot/images`, иначе на сайте они не отобразятся.
+
 ## 📚 Frontend библиотеки
 
 Bootstrap и jQuery подключены через CDN в файле `_Layout.cshtml`. Локальная папка `wwwroot/lib` не используется.


### PR DESCRIPTION
## Summary
- ignore images in CloudCityCenter/wwwroot/images
- update README to explain placing images manually

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685423283cc0832b94e0cb1dbc2ba318