### PR TITLE
Fix invalid JSON in appsettings

### DIFF
--- a/CloudCityCenter/appsettings.json
+++ b/CloudCityCenter/appsettings.json
@@ -6,8 +6,7 @@
     }
   },
   "ConnectionStrings": {
-  "DefaultConnection": "Server=10.100.210.9,1433;Database=master;User Id=sa;Password=NewSecureP@ssw0rd;TrustServerCertificate=True;"
-}
-,
+    "DefaultConnection": "Server=10.100.210.9,1433;Database=master;User Id=sa;Password=NewSecureP@ssw0rd;TrustServerCertificate=True;"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- correct JSON structure in `appsettings.json`

## Testing
- `jq . CloudCityCenter/appsettings.json`
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542d8f17b4832baab8cda016d14f4d