### PR TITLE
Add registration page

### DIFF
--- a/CloudCityCenter/Controllers/AccountController.cs
+++ b/CloudCityCenter/Controllers/AccountController.cs
@@ -1,0 +1,44 @@
+using CloudCityCenter.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CloudCityCenter.Controllers;
+
+public class AccountController : Controller
+{
+    private readonly UserManager<IdentityUser> _userManager;
+    private readonly SignInManager<IdentityUser> _signInManager;
+
+    public AccountController(UserManager<IdentityUser> userManager, SignInManager<IdentityUser> signInManager)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+    }
+
+    [HttpGet]
+    public IActionResult Register()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Register(RegisterViewModel model)
+    {
+        if (ModelState.IsValid)
+        {
+            var user = new IdentityUser { UserName = model.Email, Email = model.Email };
+            var result = await _userManager.CreateAsync(user, model.Password);
+            if (result.Succeeded)
+            {
+                await _signInManager.SignInAsync(user, isPersistent: false);
+                return RedirectToAction("Index", "Home");
+            }
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+        }
+        return View(model);
+    }
+}

--- a/CloudCityCenter/Models/RegisterViewModel.cs
+++ b/CloudCityCenter/Models/RegisterViewModel.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CloudCityCenter.Models;
+
+public class RegisterViewModel
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [DataType(DataType.Password)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required]
+    [DataType(DataType.Password)]
+    [Compare(nameof(Password), ErrorMessage = "Passwords do not match.")]
+    public string ConfirmPassword { get; set; } = string.Empty;
+}

--- a/CloudCityCenter/Views/Account/Register.cshtml
+++ b/CloudCityCenter/Views/Account/Register.cshtml
@@ -1,0 +1,32 @@
+@model CloudCityCenter.Models.RegisterViewModel
+@{
+    ViewData["Title"] = "Register";
+}
+
+<h1 class="mb-4">Register</h1>
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <form asp-action="Register" method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="mb-3">
+                <label asp-for="Email" class="form-label"></label>
+                <input asp-for="Email" class="form-control" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="Password" class="form-label"></label>
+                <input asp-for="Password" class="form-control" />
+                <span asp-validation-for="Password" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="ConfirmPassword" class="form-label"></label>
+                <input asp-for="ConfirmPassword" class="form-control" />
+                <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-primary">Register</button>
+        </form>
+    </div>
+</div>
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -32,6 +32,11 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                     </ul>
+                    <ul class="navbar-nav">
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-controller="Account" asp-action="Register">Register</a>
+                        </li>
+                    </ul>
                 </div>
             </div>
         </nav>


### PR DESCRIPTION
## Summary
- implement `AccountController` with register actions
- create `RegisterViewModel`
- add registration page view
- link to Register in layout

## Testing
- `dotnet test CloudCityCenter.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545e5b79c8832b926907e289840dba