### PR TITLE
Improve home page carousels

### DIFF
--- a/CloudCityCenter/Views/Home/_Partners.cshtml
+++ b/CloudCityCenter/Views/Home/_Partners.cshtml
@@ -1,21 +1,26 @@
-<div id="partnersCarousel" class="carousel slide mb-5" data-bs-ride="carousel">
-    <div class="carousel-inner text-center">
-        <div class="carousel-item active">
-            <img src="https://via.placeholder.com/200x80" class="mx-auto d-block partner-logo" alt="Partner 1" />
-        </div>
-        <div class="carousel-item">
-            <img src="https://via.placeholder.com/200x80" class="mx-auto d-block partner-logo" alt="Partner 2" />
-        </div>
-        <div class="carousel-item">
-            <img src="https://via.placeholder.com/200x80" class="mx-auto d-block partner-logo" alt="Partner 3" />
+<section class="py-5">
+    <div class="container">
+        <h2 class="text-center mb-4">Наши партнёры</h2>
+        <div id="partnersCarousel" class="carousel slide mb-5" data-bs-ride="carousel">
+            <div class="carousel-inner text-center">
+                <div class="carousel-item active">
+                    <img src="https://via.placeholder.com/200x80" class="mx-auto d-block partner-logo" alt="Partner 1" />
+                </div>
+                <div class="carousel-item">
+                    <img src="https://via.placeholder.com/200x80" class="mx-auto d-block partner-logo" alt="Partner 2" />
+                </div>
+                <div class="carousel-item">
+                    <img src="https://via.placeholder.com/200x80" class="mx-auto d-block partner-logo" alt="Partner 3" />
+                </div>
+            </div>
+            <button class="carousel-control-prev" type="button" data-bs-target="#partnersCarousel" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon"></span>
+                <span class="visually-hidden">Previous</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#partnersCarousel" data-bs-slide="next">
+                <span class="carousel-control-next-icon"></span>
+                <span class="visually-hidden">Next</span>
+            </button>
         </div>
     </div>
-    <button class="carousel-control-prev" type="button" data-bs-target="#partnersCarousel" data-bs-slide="prev">
-        <span class="carousel-control-prev-icon"></span>
-        <span class="visually-hidden">Previous</span>
-    </button>
-    <button class="carousel-control-next" type="button" data-bs-target="#partnersCarousel" data-bs-slide="next">
-        <span class="carousel-control-next-icon"></span>
-        <span class="visually-hidden">Next</span>
-    </button>
-</div>
+</section>

--- a/CloudCityCenter/Views/Home/_Services.cshtml
+++ b/CloudCityCenter/Views/Home/_Services.cshtml
@@ -1,33 +1,38 @@
-<div id="servicesCarousel" class="carousel slide mb-5" data-bs-ride="carousel">
-    <div class="carousel-inner">
-        <div class="carousel-item active text-center">
-            <img src="https://via.placeholder.com/1200x400" class="d-block w-100" alt="Service 1" />
-            <div class="carousel-caption d-none d-md-block">
-                <h5>Доступные цены</h5>
-                <p>Гибкие тарифы и оплата помесячно.</p>
+<section class="py-5">
+    <div class="container">
+        <h2 class="text-center mb-4">Наши услуги</h2>
+        <div id="servicesCarousel" class="carousel slide mb-5" data-bs-ride="carousel">
+            <div class="carousel-inner">
+                <div class="carousel-item active text-center">
+                    <img src="https://via.placeholder.com/1200x400" class="d-block w-100" alt="Service 1" />
+                    <div class="carousel-caption d-none d-md-block">
+                        <h5>Доступные цены</h5>
+                        <p>Гибкие тарифы и оплата помесячно.</p>
+                    </div>
+                </div>
+                <div class="carousel-item text-center">
+                    <img src="https://via.placeholder.com/1200x400" class="d-block w-100" alt="Service 2" />
+                    <div class="carousel-caption d-none d-md-block">
+                        <h5>Отзывы клиентов</h5>
+                        <p>«CloudCity помог нам запустить проект за считанные минуты.» – Анна</p>
+                    </div>
+                </div>
+                <div class="carousel-item text-center">
+                    <img src="https://via.placeholder.com/1200x400" class="d-block w-100" alt="Service 3" />
+                    <div class="carousel-caption d-none d-md-block">
+                        <h5>Поддержка 24/7</h5>
+                        <p>Наша команда всегда готова помочь.</p>
+                    </div>
+                </div>
             </div>
-        </div>
-        <div class="carousel-item text-center">
-            <img src="https://via.placeholder.com/1200x400" class="d-block w-100" alt="Service 2" />
-            <div class="carousel-caption d-none d-md-block">
-                <h5>Отзывы клиентов</h5>
-                <p>«CloudCity помог нам запустить проект за считанные минуты.» – Анна</p>
-            </div>
-        </div>
-        <div class="carousel-item text-center">
-            <img src="https://via.placeholder.com/1200x400" class="d-block w-100" alt="Service 3" />
-            <div class="carousel-caption d-none d-md-block">
-                <h5>Поддержка 24/7</h5>
-                <p>Наша команда всегда готова помочь.</p>
-            </div>
+            <button class="carousel-control-prev" type="button" data-bs-target="#servicesCarousel" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon"></span>
+                <span class="visually-hidden">Previous</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#servicesCarousel" data-bs-slide="next">
+                <span class="carousel-control-next-icon"></span>
+                <span class="visually-hidden">Next</span>
+            </button>
         </div>
     </div>
-    <button class="carousel-control-prev" type="button" data-bs-target="#servicesCarousel" data-bs-slide="prev">
-        <span class="carousel-control-prev-icon"></span>
-        <span class="visually-hidden">Previous</span>
-    </button>
-    <button class="carousel-control-next" type="button" data-bs-target="#servicesCarousel" data-bs-slide="next">
-        <span class="carousel-control-next-icon"></span>
-        <span class="visually-hidden">Next</span>
-    </button>
-</div>
+</section>

--- a/CloudCityCenter/Views/Home/_Testimonials.cshtml
+++ b/CloudCityCenter/Views/Home/_Testimonials.cshtml
@@ -1,33 +1,38 @@
-<div id="testimonialCarousel" class="carousel slide mb-5" data-bs-ride="carousel">
-    <div class="carousel-inner">
-        <div class="carousel-item active text-center">
-            <img src="https://via.placeholder.com/80" class="rounded-circle mb-3 testimonial-photo" alt="Client 1" />
-            <blockquote class="blockquote">
-                <p class="mb-0">«Лучший сервис для аренды серверов!»</p>
-                <footer class="blockquote-footer">Иван</footer>
-            </blockquote>
-        </div>
-        <div class="carousel-item text-center">
-            <img src="https://via.placeholder.com/80" class="rounded-circle mb-3 testimonial-photo" alt="Client 2" />
-            <blockquote class="blockquote">
-                <p class="mb-0">«Отличная поддержка и быстрый запуск.»</p>
-                <footer class="blockquote-footer">Мария</footer>
-            </blockquote>
-        </div>
-        <div class="carousel-item text-center">
-            <img src="https://via.placeholder.com/80" class="rounded-circle mb-3 testimonial-photo" alt="Client 3" />
-            <blockquote class="blockquote">
-                <p class="mb-0">«Надежные сервера без перебоев.»</p>
-                <footer class="blockquote-footer">Алексей</footer>
-            </blockquote>
+<section class="py-5">
+    <div class="container">
+        <h2 class="text-center mb-4">Отзывы клиентов</h2>
+        <div id="testimonialCarousel" class="carousel slide mb-5" data-bs-ride="carousel">
+            <div class="carousel-inner">
+                <div class="carousel-item active">
+                    <div class="card text-center border-0 p-4">
+                        <img src="https://via.placeholder.com/80" class="rounded-circle mx-auto mb-3 testimonial-photo" alt="Client 1" />
+                        <p class="mb-0">«Лучший сервис для аренды серверов!»</p>
+                        <footer class="blockquote-footer mt-2">Иван</footer>
+                    </div>
+                </div>
+                <div class="carousel-item">
+                    <div class="card text-center border-0 p-4">
+                        <img src="https://via.placeholder.com/80" class="rounded-circle mx-auto mb-3 testimonial-photo" alt="Client 2" />
+                        <p class="mb-0">«Отличная поддержка и быстрый запуск.»</p>
+                        <footer class="blockquote-footer mt-2">Мария</footer>
+                    </div>
+                </div>
+                <div class="carousel-item">
+                    <div class="card text-center border-0 p-4">
+                        <img src="https://via.placeholder.com/80" class="rounded-circle mx-auto mb-3 testimonial-photo" alt="Client 3" />
+                        <p class="mb-0">«Надежные сервера без перебоев.»</p>
+                        <footer class="blockquote-footer mt-2">Алексей</footer>
+                    </div>
+                </div>
+            </div>
+            <button class="carousel-control-prev" type="button" data-bs-target="#testimonialCarousel" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon"></span>
+                <span class="visually-hidden">Previous</span>
+            </button>
+            <button class="carousel-control-next" type="button" data-bs-target="#testimonialCarousel" data-bs-slide="next">
+                <span class="carousel-control-next-icon"></span>
+                <span class="visually-hidden">Next</span>
+            </button>
         </div>
     </div>
-    <button class="carousel-control-prev" type="button" data-bs-target="#testimonialCarousel" data-bs-slide="prev">
-        <span class="carousel-control-prev-icon"></span>
-        <span class="visually-hidden">Previous</span>
-    </button>
-    <button class="carousel-control-next" type="button" data-bs-target="#testimonialCarousel" data-bs-slide="next">
-        <span class="carousel-control-next-icon"></span>
-        <span class="visually-hidden">Next</span>
-    </button>
-</div>
+</section>

--- a/CloudCityCenter/wwwroot/css/site.css
+++ b/CloudCityCenter/wwwroot/css/site.css
@@ -107,3 +107,9 @@ h1, h2, h3, h4, h5, h6 {
   height: 80px;
   object-fit: cover;
 }
+
+/* Ensure carousel controls remain visible */
+.carousel-control-prev-icon,
+.carousel-control-next-icon {
+  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
+}


### PR DESCRIPTION
## Summary
- wrap carousels in `<section>` with containers
- add headings for services, partners and testimonials
- standardize testimonials as cards
- improve visibility of carousel controls

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855303d0084832b9c93169000c07656