### PR TITLE
Fix image placeholder in services carousel

### DIFF
--- a/CloudCityCenter/Views/Home/_Services.cshtml
+++ b/CloudCityCenter/Views/Home/_Services.cshtml
@@ -16,7 +16,12 @@
                                 @foreach (var server in groups[i])
                                 {
                                     <div class="col-md-4 mb-4 text-center">
-                                        <img src="@server.ImageUrl" class="d-block w-100" alt="@server.Name" />
+                                        @{
+                                            var imageUrl = string.IsNullOrWhiteSpace(server.ImageUrl)
+                                                ? "https://via.placeholder.com/300x200?text=No+Image"
+                                                : server.ImageUrl;
+                                        }
+                                        <img src="@imageUrl" class="d-block w-100" alt="@server.Name" />
                                         <div class="carousel-caption d-none d-md-block">
                                             <h5>@server.Name</h5>
                                             <p>@server.Location - $@server.PricePerMonth / month</p>


### PR DESCRIPTION
## Summary
- handle servers with missing images in services carousel

## Testing
- `dotnet test CloudCityCenter.sln`

------
https://chatgpt.com/codex/tasks/task_e_6855701d49cc832b9596dbd629bf2124