### PR TITLE
Use AsNoTracking in HomeController

### DIFF
--- a/CloudCityCenter/Controllers/HomeController.cs
+++ b/CloudCityCenter/Controllers/HomeController.cs
@@ -21,6 +21,7 @@ public class HomeController : Controller
     public async Task<IActionResult> Index()
     {
         var servers = await _context.Servers
+            .AsNoTracking()
             .Where(s => s.IsAvailable)
             .ToListAsync();
         return View(servers);


### PR DESCRIPTION
## Summary
- improve server queries on the Home page by using EF Core `AsNoTracking`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855702bb3f4832bb3411a8f2b3dd994