### PR TITLE
Update alt text for empty services slide

### DIFF
--- a/CloudCityCenter/Views/Home/_Services.cshtml
+++ b/CloudCityCenter/Views/Home/_Services.cshtml
@@ -31,7 +31,7 @@
                 else
                 {
                     <div class="carousel-item active text-center">
-                        <img src="https://via.placeholder.com/1200x400" class="d-block w-100" alt="No servers" />
+                        <img src="https://via.placeholder.com/1200x400" class="d-block w-100" alt="No servers available." />
                         <div class="carousel-caption d-none d-md-block">
                             <h5>Сервера отсутствуют</h5>
                         </div>


### PR DESCRIPTION
## Summary
- update alt text for "no servers" slide so screen readers get context

## Testing
- `dotnet test CloudCityCenter.sln`

------
https://chatgpt.com/codex/tasks/task_e_68557035b988832b86d9d103fe30747f