### PR TITLE
Add ServiceController test and controller

### DIFF
--- a/CloudCityCenter.Tests/ServiceControllerTests.cs
+++ b/CloudCityCenter.Tests/ServiceControllerTests.cs
@@ -1,0 +1,39 @@
+using CloudCityCenter.Controllers;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace CloudCityCenter.Tests;
+
+public class ServiceControllerTests
+{
+    private static ApplicationDbContext GetInMemoryDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    [Fact]
+    public async Task Index_ReturnsViewResult_WithListOfServers()
+    {
+        // Arrange
+        var context = GetInMemoryDbContext(nameof(ServiceControllerTests) + nameof(Index_ReturnsViewResult_WithListOfServers));
+        context.Servers.AddRange(
+            new Server { Id = 1, Name = "Server1", Location = "US", PricePerMonth = 10, Configuration = "Conf1", IsAvailable = true, ImageUrl = "img" },
+            new Server { Id = 2, Name = "Server2", Location = "EU", PricePerMonth = 20, Configuration = "Conf2", IsAvailable = true, ImageUrl = "img" }
+        );
+        await context.SaveChangesAsync();
+        var controller = new ServiceController(context);
+
+        // Act
+        var result = await controller.Index();
+
+        // Assert
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsAssignableFrom<List<Server>>(viewResult.Model);
+        Assert.Equal(2, model.Count);
+    }
+}

--- a/CloudCityCenter/Controllers/ServiceController.cs
+++ b/CloudCityCenter/Controllers/ServiceController.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+
+namespace CloudCityCenter.Controllers;
+
+[Authorize]
+public class ServiceController : Controller
+{
+    private readonly ApplicationDbContext _context;
+
+    public ServiceController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [AllowAnonymous]
+    public async Task<IActionResult> Index()
+    {
+        var servers = await _context.Servers.ToListAsync();
+        return View(servers);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ServiceController.Index` test using in-memory `ApplicationDbContext`
- implement minimal `ServiceController` used by the test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685586f2d4cc832b86c44de178d00a2f