### PR TITLE
Add admin role restriction for ServersController

### DIFF
--- a/CloudCityCenter.Tests/ServersAuthorizationTests.cs
+++ b/CloudCityCenter.Tests/ServersAuthorizationTests.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using CloudCityCenter.Data;
+using CloudCityCenter.Controllers;
+using Microsoft.AspNetCore.Authorization;
 
 namespace CloudCityCenter.Tests;
 
@@ -44,5 +46,26 @@ public class ServersAuthorizationTests : IClassFixture<WebApplicationFactory<Pro
 
         Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
         Assert.Contains("/Identity/Account/Login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public void Controller_HasAuthorizeAttributeWithAdminRole()
+    {
+        var attr = (AuthorizeAttribute?)Attribute.GetCustomAttribute(typeof(ServersController), typeof(AuthorizeAttribute));
+        Assert.NotNull(attr);
+        Assert.Equal("Admin", attr!.Roles);
+    }
+
+    [Fact]
+    public void IndexAndDetails_AreAllowAnonymous()
+    {
+        var indexAttr = typeof(ServersController).GetMethod(nameof(ServersController.Index))
+            ?.GetCustomAttributes(typeof(AllowAnonymousAttribute), false)
+            .FirstOrDefault();
+        var detailsAttr = typeof(ServersController).GetMethod(nameof(ServersController.Details))
+            ?.GetCustomAttributes(typeof(AllowAnonymousAttribute), false)
+            .FirstOrDefault();
+        Assert.NotNull(indexAttr);
+        Assert.NotNull(detailsAttr);
     }
 }

--- a/CloudCityCenter.Tests/ServersControllerTests.cs
+++ b/CloudCityCenter.Tests/ServersControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
+using System.Collections.Generic;
 
 namespace CloudCityCenter.Tests;
 
@@ -25,7 +26,8 @@ public class ServersControllerTests
         var httpContext = new DefaultHttpContext();
         if (authenticated)
         {
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "user1") }, "Test"));
+            var claims = new List<Claim> { new Claim(ClaimTypes.NameIdentifier, "user1"), new Claim(ClaimTypes.Role, "Admin") };
+            var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
             httpContext.User = user;
         }
         controller.ControllerContext = new ControllerContext { HttpContext = httpContext };

--- a/CloudCityCenter/Controllers/ServersController.cs
+++ b/CloudCityCenter/Controllers/ServersController.cs
@@ -7,7 +7,7 @@ using CloudCityCenter.Models;
 
 namespace CloudCityCenter.Controllers;
 
-[Authorize]
+[Authorize(Roles = "Admin")]
 public class ServersController : Controller
 {
     private readonly ApplicationDbContext _context;


### PR DESCRIPTION
## Summary
- restrict ServersController to Admin role
- include Admin role claims in controller tests
- assert controller authorization attributes

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558837a24c832b808246af33ec02d7