### PR TITLE
Add ServiceController unit tests

### DIFF
--- a/CloudCityCenter.Tests/GlobalUsings.cs
+++ b/CloudCityCenter.Tests/GlobalUsings.cs
@@ -1,1 +1,2 @@
 global using Xunit;
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/CloudCityCenter.Tests/ServiceControllerTests.cs
+++ b/CloudCityCenter.Tests/ServiceControllerTests.cs
@@ -1,44 +1,39 @@
 using CloudCityCenter.Controllers;
 using CloudCityCenter.Data;
 using CloudCityCenter.Models;
+using CloudCityCenter.Models.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.EntityFrameworkCore.Storage;
 using System;
 
 namespace CloudCityCenter.Tests;
 
-public class HomeControllerTests
+public class ServiceControllerTests
 {
     [Fact]
     public async Task Index_ReturnsViewResult_WithServers()
     {
         var root = new InMemoryDatabaseRoot();
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-            .UseInMemoryDatabase("Home_Index_ReturnsViewResult_WithServers", root)
+            .UseInMemoryDatabase("Service_Index_ReturnsViewResult_WithServers", root)
             .Options;
         await using var context = new ApplicationDbContext(options);
         await context.Database.EnsureDeletedAsync();
         await context.Database.EnsureCreatedAsync();
-        context.Servers.Add(new Server
-        {
-            Id = 1,
-            Name = "S1",
-            Location = "US",
-            PricePerMonth = 10,
-            Configuration = "C",
-            IsAvailable = true,
-            ImageUrl = "img"
-        });
+        context.Servers.AddRange(
+            new Server { Id = 1, Name = "S1", Location = "US", PricePerMonth = 10, Configuration = "C1", IsAvailable = true, ImageUrl = "img" },
+            new Server { Id = 2, Name = "S2", Location = "EU", PricePerMonth = 20, Configuration = "C2", IsAvailable = false, ImageUrl = "img" }
+        );
         await context.SaveChangesAsync();
-        var controller = new HomeController(NullLogger<HomeController>.Instance, context);
+        var controller = new ServiceController(context);
 
         var result = await controller.Index();
 
         var viewResult = Assert.IsType<ViewResult>(result);
-        var model = Assert.IsAssignableFrom<List<Server>>(viewResult.Model);
-        Assert.Single(model);
+        var model = Assert.IsType<ServiceIndexViewModel>(viewResult.Model);
+        Assert.Equal(2, model.Servers.Count());
+        Assert.Contains(model.Servers, s => s.Name == "S1");
+        Assert.Contains(model.Servers, s => s.Name == "S2");
     }
 }
-


### PR DESCRIPTION
## Summary
- add ServiceControllerTests verifying Index returns expected model
- use isolated InMemory DbContext for each test
- update HomeControllerTests to use isolated context
- disable xUnit parallelization for consistent test state

## Testing
- `dotnet test CloudCityCenter.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6855974a27dc832b8df2656400e12f67