### PR TITLE
Restrict server management links to admins

### DIFF
--- a/CloudCityCenter/Views/Servers/Details.cshtml
+++ b/CloudCityCenter/Views/Servers/Details.cshtml
@@ -49,6 +49,9 @@
     </dl>
 </div>
 <div>
-    <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a> |
+    @if (User.IsInRole("Admin"))
+    {
+        <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a> |
+    }
     <a asp-action="Index">Back to List</a>
 </div>

--- a/CloudCityCenter/Views/Servers/Index.cshtml
+++ b/CloudCityCenter/Views/Servers/Index.cshtml
@@ -6,9 +6,12 @@
 
 <h1>Servers</h1>
 
-<p>
-    <a asp-action="Create" class="btn btn-primary">Create New</a>
-</p>
+@if (User.IsInRole("Admin"))
+{
+    <p>
+        <a asp-action="Create" class="btn btn-primary">Create New</a>
+    </p>
+}
 
 <div class="row row-cols-1 row-cols-md-3 g-4">
 @foreach (var item in Model)
@@ -24,8 +27,11 @@
             </div>
             <div class="card-footer text-center">
                 <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-outline-primary me-2">Details</a>
-                <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-secondary me-2">Edit</a>
-                <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
+                @if (User.IsInRole("Admin"))
+                {
+                    <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-secondary me-2">Edit</a>
+                    <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-danger">Delete</a>
+                }
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- hide server management links from non-admin users
- keep edit link in details page only for admins

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6855974a9b70832ba9a9add039537154