### PR TITLE
Fix server views for missing images

### DIFF
--- a/CloudCityCenter/Views/Servers/Details.cshtml
+++ b/CloudCityCenter/Views/Servers/Details.cshtml
@@ -38,7 +38,12 @@
             @Html.DisplayNameFor(model => model.ImageUrl)
         </dt>
         <dd class="col-sm-10">
-            <img src="@Model.ImageUrl" class="img-fluid" alt="@Model.Name" />
+            @{
+                var imageUrl = string.IsNullOrWhiteSpace(Model.ImageUrl)
+                    ? "https://via.placeholder.com/300x200?text=No+Image"
+                    : Model.ImageUrl;
+            }
+            <img src="@imageUrl" class="img-fluid" alt="@Model.Name" />
         </dd>
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.IsAvailable)

--- a/CloudCityCenter/Views/Servers/Index.cshtml
+++ b/CloudCityCenter/Views/Servers/Index.cshtml
@@ -15,7 +15,12 @@
 {
     <div class="col">
         <div class="card h-100">
-            <img src="@item.ImageUrl" class="card-img-top" alt="@item.Name">
+            @{
+                var imageUrl = string.IsNullOrWhiteSpace(item.ImageUrl)
+                    ? "https://via.placeholder.com/300x200?text=No+Image"
+                    : item.ImageUrl;
+            }
+            <img src="@imageUrl" class="card-img-top" alt="@item.Name">
             <div class="card-body">
                 <h5 class="card-title">@item.Name</h5>
                 <p class="card-text">@item.Configuration</p>


### PR DESCRIPTION
## Summary
- handle placeholder images for servers on index and details views

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855974e7fcc832b8910af6c242cdd50