### PR TITLE
Fix Razor syntax in Servers Details view

### DIFF
--- a/CloudCityCenter/Views/Servers/Details.cshtml
+++ b/CloudCityCenter/Views/Servers/Details.cshtml
@@ -56,7 +56,7 @@
 <div>
     @if (User.IsInRole("Admin"))
     {
-        <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a> |
+        <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-primary">Edit</a> <text>|</text>
     }
     <a asp-action="Index">Back to List</a>
 </div>


### PR DESCRIPTION
## Summary
- fix Razor syntax error by wrapping vertical bar in `<text>` element

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685584a06028832baf1a43dc46e9a2d0