### PR TITLE
Seed product types with variants and legacy migration

### DIFF
--- a/CloudCityCenter/Models/ProductType.cs
+++ b/CloudCityCenter/Models/ProductType.cs
@@ -2,5 +2,7 @@ namespace CloudCityCenter.Models;
 
 public enum ProductType
 {
-    DedicatedServer
+    DedicatedServer,
+    Hosting,
+    Website
 }


### PR DESCRIPTION
## Summary
- seed starter catalog entries for dedicated servers, hosting, and websites complete with default variant and features
- migrate any legacy `Servers` rows into the unified `Products` table
- expand `ProductType` enum to support hosting and website offerings

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a455fb27a4832b909e7ccad752b951