### PR TITLE
Expose published dedicated servers via slug-based details

### DIFF
--- a/CloudCityCenter/Models/Product.cs
+++ b/CloudCityCenter/Models/Product.cs
@@ -29,6 +29,8 @@ public class Product
 
     public bool IsAvailable { get; set; }
 
+    public bool IsPublished { get; set; }
+
     [StringLength(300)]
     public string? ImageUrl { get; set; }
 

--- a/CloudCityCenter/Models/ViewModels/ProductCardVm.cs
+++ b/CloudCityCenter/Models/ViewModels/ProductCardVm.cs
@@ -1,0 +1,12 @@
+namespace CloudCityCenter.Models.ViewModels;
+
+public class ProductCardVm
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public string Location { get; set; } = string.Empty;
+    public decimal PricePerMonth { get; set; }
+    public string Configuration { get; set; } = string.Empty;
+    public string? ImageUrl { get; set; }
+}

--- a/CloudCityCenter/Views/Servers/Details.cshtml
+++ b/CloudCityCenter/Views/Servers/Details.cshtml
@@ -52,6 +52,41 @@
             @Html.DisplayFor(model => model.IsAvailable)
         </dd>
     </dl>
+
+    @if (Model.Variants.Any())
+    {
+        <h4>Variants</h4>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Price</th>
+                    <th>Billing Period</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var variant in Model.Variants)
+            {
+                <tr>
+                    <td>@variant.Name</td>
+                    <td>@variant.Price</td>
+                    <td>@variant.BillingPeriod</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    }
+
+    @if (Model.Features.Any())
+    {
+        <h4>Features</h4>
+        <ul class="list-unstyled">
+        @foreach (var feature in Model.Features)
+        {
+            <li><strong>@feature.Name</strong>@(string.IsNullOrWhiteSpace(feature.Value) ? string.Empty : $": {feature.Value}")</li>
+        }
+        </ul>
+    }
 </div>
 <div>
     @if (User.IsInRole("Admin"))

--- a/CloudCityCenter/Views/Servers/Index.cshtml
+++ b/CloudCityCenter/Views/Servers/Index.cshtml
@@ -1,4 +1,4 @@
-@model IEnumerable<CloudCityCenter.Models.Product>
+@model IEnumerable<CloudCityCenter.Models.ViewModels.ProductCardVm>
 
 @{
     ViewData["Title"] = "Servers";
@@ -31,7 +31,7 @@
                 <p class="card-text"><small class="text-muted">@item.Location</small></p>
             </div>
             <div class="card-footer text-center">
-                <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-sm btn-outline-primary me-2">Details</a>
+                <a asp-action="Details" asp-route-slug="@item.Slug" class="btn btn-sm btn-outline-primary me-2">Details</a>
                 @if (User.IsInRole("Admin"))
                 {
                     <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-secondary me-2">Edit</a>


### PR DESCRIPTION
## Summary
- Filter dedicated servers to only published products and map them to `ProductCardVm`
- Show server details by slug including variants and features
- Add `ProductCardVm` view model and update Razor views

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a45825ba24832bb51ff5f817a1cd32