### PR TITLE
Prune obsolete product links from layout

### DIFF
--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -35,18 +35,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Servers" asp-action="Index">Servers</a>
                         </li>
                         <li class="nav-item">
-                              <a class="nav-link text-dark" asp-area="" asp-controller="VPS" asp-action="Index">VPS</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="VPN" asp-action="Index">VPN</a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Hosting" asp-action="Index">Hosting</a>
-                        </li>
-  
-            
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Service" asp-action="Index">Services</a>
                         </li>
                         <!-- <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Orders" asp-action="Index">Orders</a>


### PR DESCRIPTION
## Summary
- remove outdated VPS/VPN/Service nav links from layout
- keep Servers and Hosting navigation pointing to current routes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a45d8124b8832b973d670a14b05557