### PR TITLE
Run migrations at startup and clean up seeding

### DIFF
--- a/CloudCityCenter/Data/SeedData.cs
+++ b/CloudCityCenter/Data/SeedData.cs
@@ -12,8 +12,6 @@ public static class SeedData
 {
     public static void Initialize(ApplicationDbContext context)
     {
-        context.Database.Migrate();
-
         MigrateLegacyServers(context);
         SeedProducts(context);
 


### PR DESCRIPTION
## Summary
- create scope after building the app to run EF Core migrations with error logging
- seed data from Program when `seed` arg is provided
- remove redundant migration call in `SeedData.Initialize`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a46106d988832b93a58a8827bcb0d4