### PR TITLE
Adjust navbar expansion breakpoint to md

### DIFF
--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
         var currentController = ViewContext.RouteData.Values["controller"]?.ToString();
     }
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+        <nav class="navbar navbar-expand-md navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container-fluid">
                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">
     <img src="~/images/logo.png" alt="CloudCityCenter Logo" style="height:40px;">
@@ -30,7 +30,7 @@
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                <div class="navbar-collapse collapse d-md-inline-flex justify-content-between">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
                             <a class="nav-link text-dark @(currentController == "Home" ? "active" : "")" asp-area="" asp-controller="Home" asp-action="Index">@Localizer["Home"]</a>


### PR DESCRIPTION
## Summary
- use the `md` breakpoint for navbar expansion so the menu collapses below 768px
- update collapse container utility class to match `md` breakpoint

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e6f98e40832bada304d626349ff4