### PR TITLE
Remove Home menu entry from navigation

### DIFF
--- a/CloudCityCenter/Resources/Shared/_Layout.en.resx
+++ b/CloudCityCenter/Resources/Shared/_Layout.en.resx
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <data name="Home" xml:space="preserve">
-    <value>Home</value>
-  </data>
   <data name="Servers" xml:space="preserve">
     <value>Servers</value>
   </data>

--- a/CloudCityCenter/Resources/Shared/_Layout.resx
+++ b/CloudCityCenter/Resources/Shared/_Layout.resx
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <data name="Home" xml:space="preserve">
-    <value>Home</value>
-  </data>
   <data name="Servers" xml:space="preserve">
     <value>Servers</value>
   </data>

--- a/CloudCityCenter/Resources/Shared/_Layout.ru.resx
+++ b/CloudCityCenter/Resources/Shared/_Layout.ru.resx
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <data name="Home" xml:space="preserve">
-    <value>Главная</value>
-  </data>
   <data name="Servers" xml:space="preserve">
     <value>Серверы</value>
   </data>

--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -33,9 +33,6 @@
                 <div class="navbar-collapse collapse d-md-inline-flex justify-content-between">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark @(currentController == "Home" ? "active" : "")" asp-area="" asp-controller="Home" asp-action="Index">@Localizer["Home"]</a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link text-dark @(currentController == "Servers" ? "active" : "")" asp-area="" asp-controller="Servers" asp-action="Index">@Localizer["Servers"]</a>
                         </li>
                         <li class="nav-item">


### PR DESCRIPTION
## Summary
- remove Home link from navbar
- drop obsolete Home localization entries

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a6ec95b948832ba9f866546904c1bf