### PR TITLE
Use pseudo-element underline for active nav links

### DIFF
--- a/CloudCityCenter/wwwroot/css/site.css
+++ b/CloudCityCenter/wwwroot/css/site.css
@@ -32,10 +32,30 @@ body {
   font-family: 'Segoe UI', sans-serif;
 }
 
+/* Navigation link styling */
+.nav-link {
+  position: relative;
+  padding-bottom: .25rem;
+}
+
 .nav-link.active {
   color: var(--primary-color) !important;
-  text-decoration: underline;
-  border-bottom: 2px solid var(--primary-color);
+}
+
+.nav-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 3px;
+  background-color: var(--primary-color);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.nav-link.active::after {
+  width: 100%;
 }
 
 .hero {


### PR DESCRIPTION
## Summary
- style navigation links with relative positioning and bottom padding
- highlight active nav links with animated underline using ::after pseudo-element

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68a6f23c6508832babbf3caffaec85bd