### PR TITLE
Add server migration

### DIFF
--- a/CloudCityCenter/Migrations/20250821125710_AddServer.Designer.cs
+++ b/CloudCityCenter/Migrations/20250821125710_AddServer.Designer.cs
@@ -4,6 +4,7 @@ using CloudCityCenter.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CloudCityCenter.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250821125710_AddServer")]
+    partial class AddServer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CloudCityCenter/Migrations/20250821125710_AddServer.cs
+++ b/CloudCityCenter/Migrations/20250821125710_AddServer.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CloudCityCenter.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddServer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Servers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Slug = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    Location = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    PricePerMonth = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
+                    CpuCores = table.Column<int>(type: "int", nullable: false),
+                    RamGb = table.Column<int>(type: "int", nullable: false),
+                    StorageGb = table.Column<int>(type: "int", nullable: false),
+                    ImageUrl = table.Column<string>(type: "nvarchar(300)", maxLength: 300, nullable: true),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                    DDoSTier = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false, defaultValue: "Basic"),
+                    Stock = table.Column<int>(type: "int", nullable: false, defaultValue: 9999),
+                    CreatedUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Servers", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Servers_Slug",
+                table: "Servers",
+                column: "Slug",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Servers");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add AddServer EF Core migration with default values and slug index

## Testing
- `dotnet ef migrations add AddServer --project CloudCityCenter`
- `dotnet ef database update --project CloudCityCenter` *(fails: LocalDB is not supported on this platform)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a7171712bc832b999a509783aa6233