### PR TITLE
Add integration tests for server authorization and filtering

### DIFF
--- a/CloudCityCenter.Tests/AdminServersAuthorizationTests.cs
+++ b/CloudCityCenter.Tests/AdminServersAuthorizationTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace CloudCityCenter.Tests;
+
+public class AdminServersAuthorizationTests
+{
+    [Fact]
+    public async Task Get_AdminServers_Unauthenticated_RedirectsToLogin()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var response = await client.GetAsync("/Admin/Servers");
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AdminServers_NonAdmin_Forbidden()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        client.DefaultRequestHeaders.Add("X-User", "user");
+
+        var response = await client.GetAsync("/Admin/Servers");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_AdminServers_Admin_Ok()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+        client.DefaultRequestHeaders.Add("X-User", "admin");
+        client.DefaultRequestHeaders.Add("X-Role", "Admin");
+
+        var response = await client.GetAsync("/Admin/Servers");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}
+

--- a/CloudCityCenter.Tests/CustomWebApplicationFactory.cs
+++ b/CloudCityCenter.Tests/CustomWebApplicationFactory.cs
@@ -1,0 +1,41 @@
+using CloudCityCenter.Data;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    private readonly string _dbName = Guid.NewGuid().ToString();
+
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContext<ApplicationDbContext>(options =>
+            {
+                options.UseInMemoryDatabase(_dbName);
+            });
+
+            services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = TestAuthHandler.Scheme;
+                options.DefaultChallengeScheme = TestAuthHandler.Scheme;
+            }).AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.Scheme, _ => { });
+
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.Database.EnsureCreated();
+        });
+    }
+}
+

--- a/CloudCityCenter.Tests/ServersEndpointIntegrationTests.cs
+++ b/CloudCityCenter.Tests/ServersEndpointIntegrationTests.cs
@@ -1,0 +1,34 @@
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+
+namespace CloudCityCenter.Tests;
+
+public class ServersEndpointIntegrationTests
+{
+    [Fact]
+    public async Task Get_Servers_OnlyActiveAndFiltered()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.Servers.AddRange(
+            new Server { Name = "ActiveUS", Slug = "a", Location = "US", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = true },
+            new Server { Name = "InactiveUS", Slug = "b", Location = "US", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = false },
+            new Server { Name = "ActiveEU", Slug = "c", Location = "EU", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = true }
+        );
+        db.SaveChanges();
+
+        var response = await client.GetAsync("/Servers?location=US");
+
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("ActiveUS", content);
+        Assert.DoesNotContain("InactiveUS", content);
+        Assert.DoesNotContain("ActiveEU", content);
+    }
+}
+

--- a/CloudCityCenter.Tests/TestAuthHandler.cs
+++ b/CloudCityCenter.Tests/TestAuthHandler.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public new const string Scheme = "Test";
+
+    public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+        : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.ContainsKey("X-User"))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var claims = new List<Claim> { new Claim(ClaimTypes.Name, Request.Headers["X-User"]) };
+        var role = Request.Headers["X-Role"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(role))
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var identity = new ClaimsIdentity(claims, Scheme);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = (int)HttpStatusCode.Redirect;
+        Response.Headers.Location = "/Identity/Account/Login";
+        return Task.CompletedTask;
+    }
+}
+

--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -90,6 +90,11 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllerRoute(
+    name: "areas",
+    pattern: "{area:exists}/{controller=Home}/{action=Index}/{id?}"
+);
+
+app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
 


### PR DESCRIPTION
## Summary
- add area routing to support Admin endpoints
- create in-memory WebApplicationFactory with test auth handler
- verify admin server endpoints enforce authorization
- ensure public /Servers endpoint only lists active, filtered servers

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a7231cf74c832b95241920566e3045