### PR TITLE
Refactor server CPU field and validation

### DIFF
--- a/CloudCityCenter.Tests/ServersControllerTests.cs
+++ b/CloudCityCenter.Tests/ServersControllerTests.cs
@@ -24,9 +24,9 @@ public class ServersControllerTests
     {
         var context = GetContext(nameof(Index_FiltersSortsAndPaginates));
         context.Servers.AddRange(
-            new Server { Name = "A", Slug = "a", Location = "US", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 100, IsActive = true },
-            new Server { Name = "B", Slug = "b", Location = "EU", CpuCores = 8, RamGb = 32, StorageGb = 200, PricePerMonth = 50, IsActive = true },
-            new Server { Name = "C", Slug = "c", Location = "US", CpuCores = 2, RamGb = 8, StorageGb = 100, PricePerMonth = 150, IsActive = false }
+            new Server { Name = "A", Slug = "a", Location = "US", CPU = "4 cores", RamGb = 16, StorageGb = 100, PricePerMonth = 100, IsActive = true },
+            new Server { Name = "B", Slug = "b", Location = "EU", CPU = "8 cores", RamGb = 32, StorageGb = 200, PricePerMonth = 50, IsActive = true },
+            new Server { Name = "C", Slug = "c", Location = "US", CPU = "2 cores", RamGb = 8, StorageGb = 100, PricePerMonth = 150, IsActive = false }
         );
         await context.SaveChangesAsync();
 
@@ -45,8 +45,8 @@ public class ServersControllerTests
     {
         var context = GetContext(nameof(Details_ReturnsNotFound_ForMissingOrInactive));
         context.Servers.AddRange(
-            new Server { Name = "A", Slug = "a", Location = "US", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 100, IsActive = true },
-            new Server { Name = "C", Slug = "c", Location = "US", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 100, IsActive = false }
+            new Server { Name = "A", Slug = "a", Location = "US", CPU = "4 cores", RamGb = 16, StorageGb = 100, PricePerMonth = 100, IsActive = true },
+            new Server { Name = "C", Slug = "c", Location = "US", CPU = "4 cores", RamGb = 16, StorageGb = 100, PricePerMonth = 100, IsActive = false }
         );
         await context.SaveChangesAsync();
 

--- a/CloudCityCenter.Tests/ServersEndpointIntegrationTests.cs
+++ b/CloudCityCenter.Tests/ServersEndpointIntegrationTests.cs
@@ -16,9 +16,9 @@ public class ServersEndpointIntegrationTests
         using var scope = factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         db.Servers.AddRange(
-            new Server { Name = "ActiveUS", Slug = "a", Location = "US", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = true },
-            new Server { Name = "InactiveUS", Slug = "b", Location = "US", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = false },
-            new Server { Name = "ActiveEU", Slug = "c", Location = "EU", CpuCores = 4, RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = true }
+            new Server { Name = "ActiveUS", Slug = "a", Location = "US", CPU = "4 cores", RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = true },
+            new Server { Name = "InactiveUS", Slug = "b", Location = "US", CPU = "4 cores", RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = false },
+            new Server { Name = "ActiveEU", Slug = "c", Location = "EU", CPU = "4 cores", RamGb = 16, StorageGb = 100, PricePerMonth = 10, IsActive = true }
         );
         db.SaveChanges();
 

--- a/CloudCityCenter/Areas/Admin/Controllers/ServersController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/ServersController.cs
@@ -55,7 +55,7 @@ public class ServersController : Controller
     // POST: Admin/Servers/Create
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind("Id,Name,Slug,Description,Location,PricePerMonth,CpuCores,RamGb,StorageGb,ImageUrl,IsActive,DDoSTier,Stock")] Server server)
+    public async Task<IActionResult> Create([Bind("Id,Name,Slug,Description,Location,PricePerMonth,CPU,RamGb,StorageGb,ImageUrl,IsActive,DDoSTier,Stock")] Server server)
     {
         if (!ModelState.IsValid)
         {
@@ -102,7 +102,7 @@ public class ServersController : Controller
     // POST: Admin/Servers/Edit/5
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Edit(int id, [Bind("Id,Name,Slug,Description,Location,PricePerMonth,CpuCores,RamGb,StorageGb,ImageUrl,IsActive,DDoSTier,Stock")] Server server)
+    public async Task<IActionResult> Edit(int id, [Bind("Id,Name,Slug,Description,Location,PricePerMonth,CPU,RamGb,StorageGb,ImageUrl,IsActive,DDoSTier,Stock")] Server server)
     {
         if (id != server.Id)
         {

--- a/CloudCityCenter/Areas/Admin/Views/Servers/Create.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Servers/Create.cshtml
@@ -43,9 +43,9 @@
                 <span asp-validation-for="PricePerMonth" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="CpuCores" class="form-label"></label>
-                <input asp-for="CpuCores" class="form-control" />
-                <span asp-validation-for="CpuCores" class="text-danger"></span>
+                <label asp-for="CPU" class="form-label"></label>
+                <input asp-for="CPU" class="form-control" />
+                <span asp-validation-for="CPU" class="text-danger"></span>
             </div>
             <div class="mb-3">
                 <label asp-for="RamGb" class="form-label"></label>

--- a/CloudCityCenter/Areas/Admin/Views/Servers/Details.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Servers/Details.cshtml
@@ -24,8 +24,8 @@
         <dd class="col-sm-10">@Model.Location</dd>
         <dt class="col-sm-2">Price</dt>
         <dd class="col-sm-10">@Model.PricePerMonth</dd>
-        <dt class="col-sm-2">CpuCores</dt>
-        <dd class="col-sm-10">@Model.CpuCores</dd>
+        <dt class="col-sm-2">CPU</dt>
+        <dd class="col-sm-10">@Model.CPU</dd>
         <dt class="col-sm-2">RamGb</dt>
         <dd class="col-sm-10">@Model.RamGb</dd>
         <dt class="col-sm-2">StorageGb</dt>

--- a/CloudCityCenter/Areas/Admin/Views/Servers/Edit.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Servers/Edit.cshtml
@@ -39,9 +39,9 @@
                 <span asp-validation-for="PricePerMonth" class="text-danger"></span>
             </div>
             <div class="mb-3">
-                <label asp-for="CpuCores" class="form-label"></label>
-                <input asp-for="CpuCores" class="form-control" />
-                <span asp-validation-for="CpuCores" class="text-danger"></span>
+                <label asp-for="CPU" class="form-label"></label>
+                <input asp-for="CPU" class="form-control" />
+                <span asp-validation-for="CPU" class="text-danger"></span>
             </div>
             <div class="mb-3">
                 <label asp-for="RamGb" class="form-label"></label>

--- a/CloudCityCenter/Controllers/ServersController.cs
+++ b/CloudCityCenter/Controllers/ServersController.cs
@@ -73,11 +73,11 @@ public class ServersController : Controller
         var servers = await query
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
-            .Select(s => new ServerCardVm
+                .Select(s => new ServerCardVm
             {
                 ImageUrl = s.ImageUrl,
                 Name = s.Name,
-                CpuCores = s.CpuCores,
+                CPU = s.CPU,
                 RamGb = s.RamGb,
                 StorageGb = s.StorageGb,
                 Location = s.Location,

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -213,8 +213,10 @@ namespace CloudCityCenter.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("CpuCores")
-                        .HasColumnType("int");
+                    b.Property<string>("CPU")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
 
                     b.Property<DateTime>("CreatedUtc")
                         .ValueGeneratedOnAdd()
@@ -242,13 +244,14 @@ namespace CloudCityCenter.Migrations
                         .HasDefaultValue(true);
 
                     b.Property<string>("Location")
+                        .IsRequired()
                         .HasMaxLength(100)
                         .HasColumnType("nvarchar(100)");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
 
                     b.Property<decimal>("PricePerMonth")
                         .HasPrecision(18, 2)

--- a/CloudCityCenter/Models/Server.cs
+++ b/CloudCityCenter/Models/Server.cs
@@ -13,7 +13,7 @@ public class Server
     private string _name = string.Empty;
 
     [Required]
-    [StringLength(100)]
+    [StringLength(200)]
     public string Name
     {
         get => _name;
@@ -40,19 +40,20 @@ public class Server
     [StringLength(200)]
     public string? Description { get; set; }
 
+    [Required]
     [StringLength(100)]
     public string? Location { get; set; }
 
     [Range(0, double.MaxValue)]
     public decimal PricePerMonth { get; set; }
 
-    [Range(1, int.MaxValue)]
-    public int CpuCores { get; set; }
+    [StringLength(100)]
+    public string CPU { get; set; } = string.Empty;
 
-    [Range(1, int.MaxValue)]
+    [Range(0, int.MaxValue)]
     public int RamGb { get; set; }
 
-    [Range(1, int.MaxValue)]
+    [Range(0, int.MaxValue)]
     public int StorageGb { get; set; }
 
     private string? _imageUrl;

--- a/CloudCityCenter/Models/ViewModels/ServerCardVm.cs
+++ b/CloudCityCenter/Models/ViewModels/ServerCardVm.cs
@@ -7,7 +7,7 @@ public record ServerCardVm
 {
     public string? ImageUrl { get; init; }
     public string Name { get; init; } = string.Empty;
-    public int CpuCores { get; init; }
+    public string CPU { get; init; } = string.Empty;
     public int RamGb { get; init; }
     public int StorageGb { get; init; }
     public string? Location { get; init; }

--- a/CloudCityCenter/Views/Servers/Details.cshtml
+++ b/CloudCityCenter/Views/Servers/Details.cshtml
@@ -15,7 +15,7 @@
     </div>
     <div class="col-md-6">
         <ul class="list-unstyled">
-            <li><strong>CPU:</strong> @Model.CpuCores cores</li>
+            <li><strong>CPU:</strong> @Model.CPU</li>
             <li><strong>RAM:</strong> @Model.RamGb GB</li>
             <li><strong>Storage:</strong> @Model.StorageGb GB</li>
             <li><strong>DDoS Tier:</strong> @Model.DDoSTier</li>

--- a/CloudCityCenter/Views/Servers/Index.cshtml
+++ b/CloudCityCenter/Views/Servers/Index.cshtml
@@ -29,7 +29,7 @@ else
                     <div class="card-body">
                         <h5 class="card-title">@item.Name</h5>
                         <ul class="list-unstyled small">
-                            <li>CPU: @item.CpuCores cores</li>
+                            <li>CPU: @item.CPU</li>
                             <li>RAM: @item.RamGb GB</li>
                             <li>Storage: @item.StorageGb GB</li>
                             <li>Location: @item.Location</li>

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Remember to update the service after applying migrations.
   `/Admin/Servers`
 - Поля модели `Server` и изображения:
   `Server` fields and image paths:
-  Ключевые поля: `Name`, `Slug` (auto), `Description`, `Location`, `PricePerMonth`, `CpuCores`, `RamGb`, `StorageGb`, `ImageUrl`, `IsActive`, `DDoSTier`, `Stock`, `CreatedUtc`.
-  Key fields: `Name`, `Slug` (auto), `Description`, `Location`, `PricePerMonth`, `CpuCores`, `RamGb`, `StorageGb`, `ImageUrl`, `IsActive`, `DDoSTier`, `Stock`, `CreatedUtc`.
+  Ключевые поля: `Name`, `Slug` (auto), `Description`, `Location`, `PricePerMonth`, `CPU`, `RamGb`, `StorageGb`, `ImageUrl`, `IsActive`, `DDoSTier`, `Stock`, `CreatedUtc`.
+  Key fields: `Name`, `Slug` (auto), `Description`, `Location`, `PricePerMonth`, `CPU`, `RamGb`, `StorageGb`, `ImageUrl`, `IsActive`, `DDoSTier`, `Stock`, `CreatedUtc`.
   `ImageUrl` сохраняется как `/images/servers/<файл>`, изображения размещайте в `wwwroot/images/servers`.
   `ImageUrl` is stored as `/images/servers/<file>`; place images in `wwwroot/images/servers`.


### PR DESCRIPTION
## Summary
- Allow longer server names and require location
- Replace numeric CpuCores with string CPU field across model, controllers and views
- Permit zero for RAM and storage values

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a72c912a78832baff3a849b965f405