### PR TITLE
Remove redundant server fields from admin views

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/ServersController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/ServersController.cs
@@ -55,7 +55,7 @@ public class ServersController : Controller
     // POST: Admin/Servers/Create
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind("Id,Name,Slug,Description,Location,PricePerMonth,CPU,RamGb,StorageGb,ImageUrl,IsActive,DDoSTier,Stock")] Server server)
+    public async Task<IActionResult> Create([Bind("Name,Slug,Description,Location,PricePerMonth,CPU,RamGb,StorageGb,ImageUrl,IsActive,DDoSTier,Stock")] Server server)
     {
         if (!ModelState.IsValid)
         {

--- a/CloudCityCenter/Areas/Admin/Views/Servers/Create.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Servers/Create.cshtml
@@ -13,11 +13,6 @@
         <form asp-action="Create">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="mb-3">
-                <label asp-for="Id" class="form-label"></label>
-                <input asp-for="Id" class="form-control" />
-                <span asp-validation-for="Id" class="text-danger"></span>
-            </div>
-            <div class="mb-3">
                 <label asp-for="Name" class="form-label"></label>
                 <input asp-for="Name" class="form-control" />
                 <span asp-validation-for="Name" class="text-danger"></span>
@@ -75,11 +70,6 @@
                 <label asp-for="Stock" class="form-label"></label>
                 <input asp-for="Stock" class="form-control" />
                 <span asp-validation-for="Stock" class="text-danger"></span>
-            </div>
-            <div class="mb-3">
-                <label asp-for="CreatedUtc" class="form-label"></label>
-                <input asp-for="CreatedUtc" class="form-control" />
-                <span asp-validation-for="CreatedUtc" class="text-danger"></span>
             </div>
             <button type="submit" class="btn btn-primary">Create</button>
             <a asp-action="Index" class="btn btn-secondary">Back to List</a>

--- a/CloudCityCenter/Areas/Admin/Views/Servers/Edit.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Servers/Edit.cshtml
@@ -12,7 +12,6 @@
     <div class="col-md-6">
         <form asp-action="Edit">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <input type="hidden" asp-for="Id" />
             <div class="mb-3">
                 <label asp-for="Name" class="form-label"></label>
                 <input asp-for="Name" class="form-control" />
@@ -71,11 +70,6 @@
                 <label asp-for="Stock" class="form-label"></label>
                 <input asp-for="Stock" class="form-control" />
                 <span asp-validation-for="Stock" class="text-danger"></span>
-            </div>
-            <div class="mb-3">
-                <label asp-for="CreatedUtc" class="form-label"></label>
-                <input asp-for="CreatedUtc" class="form-control" />
-                <span asp-validation-for="CreatedUtc" class="text-danger"></span>
             </div>
             <button type="submit" class="btn btn-primary">Save</button>
             <a asp-action="Index" class="btn btn-secondary">Back to List</a>


### PR DESCRIPTION
## Summary
- remove Id and CreatedUtc inputs from admin server Create/Edit pages
- stop binding Id on server creation

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a73119dc54832ba29fa1efeec6b7cc