### PR TITLE
Route server details by slug

### DIFF
--- a/CloudCityCenter.Tests/ServersControllerTests.cs
+++ b/CloudCityCenter.Tests/ServersControllerTests.cs
@@ -5,6 +5,7 @@ using CloudCityCenter.Models.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace CloudCityCenter.Tests;
@@ -82,6 +83,33 @@ public class ServersControllerTests
         var viewResult = Assert.IsType<ViewResult>(okResult);
         var model = Assert.IsType<Server>(viewResult.Model);
         Assert.Equal("A", model.Name);
+    }
+
+    [Fact]
+    public async Task Get_Server_BySlug_ReturnsDetailsView()
+    {
+        await using var factory = new CustomWebApplicationFactory();
+        var client = factory.CreateClient();
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.Servers.Add(new Server
+        {
+            Name = "Alpha",
+            Slug = "alpha",
+            Location = "US",
+            CPU = "4 cores",
+            RamGb = 16,
+            StorageGb = 100,
+            PricePerMonth = 10,
+            IsActive = true
+        });
+        db.SaveChanges();
+
+        var response = await client.GetAsync("/Servers/alpha");
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Alpha", content);
     }
 }
 

--- a/CloudCityCenter/Controllers/ServersController.cs
+++ b/CloudCityCenter/Controllers/ServersController.cs
@@ -11,6 +11,7 @@ namespace CloudCityCenter.Controllers;
 /// <summary>
 /// Public controller for browsing available servers.
 /// </summary>
+[Route("[controller]")]
 public class ServersController : Controller
 {
     private readonly ApplicationDbContext _context;
@@ -23,6 +24,7 @@ public class ServersController : Controller
     /// <summary>
     /// Lists active servers with optional filtering, sorting and pagination.
     /// </summary>
+    [HttpGet]
     public async Task<IActionResult> Index(
         string? location,
         int? minRam,
@@ -127,6 +129,7 @@ public class ServersController : Controller
     /// <summary>
     /// Shows details for a server identified by slug.
     /// </summary>
+    [HttpGet("{slug}")]
     public async Task<IActionResult> Details(string? slug)
     {
         if (string.IsNullOrWhiteSpace(slug))

--- a/CloudCityCenter/Views/Servers/Index.cshtml
+++ b/CloudCityCenter/Views/Servers/Index.cshtml
@@ -37,7 +37,7 @@ else
                         <p class="card-text fw-semibold">$@item.PricePerMonth / month</p>
                     </div>
                     <div class="card-footer text-center">
-                        <a asp-action="Details" asp-route-slug="@item.Slug" class="btn btn-sm btn-outline-primary">Details</a>
+                        <a asp-controller="Servers" asp-action="Details" asp-route-slug="@item.Slug" class="btn btn-sm btn-outline-primary">Details</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- expose server details at `/Servers/{slug}` via attribute routing
- update server listing links to target slug route
- add test for slug-based server details endpoint

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7dacc40f0832bba0b5c4d87be6378