### PR TITLE
Handle absolute server image URLs

### DIFF
--- a/CloudCityCenter.Tests/ServerImageUrlTests.cs
+++ b/CloudCityCenter.Tests/ServerImageUrlTests.cs
@@ -1,0 +1,23 @@
+using CloudCityCenter.Models;
+
+namespace CloudCityCenter.Tests;
+
+public class ServerImageUrlTests
+{
+    [Fact]
+    public void ImageUrl_Rewrites_Relative_FileName()
+    {
+        var server = new Server { Name = "S", Location = "US" };
+        server.ImageUrl = "pic.png";
+        Assert.Equal("/images/servers/pic.png", server.ImageUrl);
+    }
+
+    [Fact]
+    public void ImageUrl_Preserves_Absolute_Url()
+    {
+        var server = new Server { Name = "S", Location = "US" };
+        var url = "https://example.com/pic.png";
+        server.ImageUrl = url;
+        Assert.Equal(url, server.ImageUrl);
+    }
+}

--- a/CloudCityCenter/Models/Server.cs
+++ b/CloudCityCenter/Models/Server.cs
@@ -68,6 +68,10 @@ public class Server
             {
                 _imageUrl = null;
             }
+            else if (Uri.IsWellFormedUriString(value, UriKind.Absolute))
+            {
+                _imageUrl = value;
+            }
             else
             {
                 var fileName = Path.GetFileName(value);


### PR DESCRIPTION
## Summary
- allow absolute URLs for server images while keeping relative filename rewrite
- test both relative and absolute image paths

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b7dfe21b40832baeffaeffd64802d9