### PR TITLE
Use EF Like for sanitized server search

### DIFF
--- a/CloudCityCenter.Tests/ServersControllerTests.cs
+++ b/CloudCityCenter.Tests/ServersControllerTests.cs
@@ -65,6 +65,34 @@ public class ServersControllerTests
     }
 
     [Fact]
+    public async Task Index_Search_IsCaseInsensitive()
+    {
+        var context = GetContext(nameof(Index_Search_IsCaseInsensitive));
+        context.Servers.Add(new Server
+        {
+            Name = "Alpha",
+            Slug = "alpha",
+            Location = "US",
+            CPU = "4 cores",
+            RamGb = 16,
+            StorageGb = 100,
+            PricePerMonth = 100,
+            IsActive = true
+        });
+        await context.SaveChangesAsync();
+
+        var controller = new ServersController(context);
+
+        var lowerResult = await controller.Index(location: null, minRam: null, maxRam: null, q: "alpha", sort: null, page: 1, pageSize: 12);
+        var lowerModel = Assert.IsAssignableFrom<ServerIndexViewModel>(Assert.IsType<ViewResult>(lowerResult).Model);
+        Assert.Single(lowerModel.Servers);
+
+        var upperResult = await controller.Index(location: null, minRam: null, maxRam: null, q: "ALPHA", sort: null, page: 1, pageSize: 12);
+        var upperModel = Assert.IsAssignableFrom<ServerIndexViewModel>(Assert.IsType<ViewResult>(upperResult).Model);
+        Assert.Single(upperModel.Servers);
+    }
+
+    [Fact]
     public async Task Details_ReturnsNotFound_ForMissingOrInactive()
     {
         var context = GetContext(nameof(Details_ReturnsNotFound_ForMissingOrInactive));

--- a/CloudCityCenter/Controllers/ServersController.cs
+++ b/CloudCityCenter/Controllers/ServersController.cs
@@ -58,11 +58,12 @@ public class ServersController : Controller
 
         if (!string.IsNullOrWhiteSpace(q))
         {
+            var safeQ = q.Replace("!", "!!").Replace("%", "!%").Replace("_", "!_");
             query = query.Where(s =>
-                s.Name.Contains(q) ||
-                (s.Description != null && s.Description.Contains(q)) ||
-                s.CPU.Contains(q) ||
-                s.Location.Contains(q));
+                EF.Functions.Like(s.Name, $"%{safeQ}%", "!") ||
+                (s.Description != null && EF.Functions.Like(s.Description, $"%{safeQ}%", "!")) ||
+                EF.Functions.Like(s.CPU, $"%{safeQ}%", "!") ||
+                EF.Functions.Like(s.Location, $"%{safeQ}%", "!"));
         }
 
         query = sort switch


### PR DESCRIPTION
## Summary
- sanitize search text to avoid wildcard injection
- use EF.Functions.Like for server fields
- test case-insensitive server searching

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e0d273b8832b99a9f5978b6391ab