### PR TITLE
Add session-based cart and checkout integration

### DIFF
--- a/CloudCityCenter/Controllers/CartController.cs
+++ b/CloudCityCenter/Controllers/CartController.cs
@@ -1,0 +1,110 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using CloudCityCenter.Models.ViewModels;
+
+namespace CloudCityCenter.Controllers;
+
+public class CartController : Controller
+{
+    private readonly ApplicationDbContext _context;
+    private const string CartSessionKey = "Cart";
+
+    public CartController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    private List<OrderItem> GetCart()
+    {
+        var cartJson = HttpContext.Session.GetString(CartSessionKey);
+        return cartJson != null
+            ? JsonSerializer.Deserialize<List<OrderItem>>(cartJson) ?? new List<OrderItem>()
+            : new List<OrderItem>();
+    }
+
+    private void SaveCart(List<OrderItem> cart)
+    {
+        HttpContext.Session.SetString(CartSessionKey, JsonSerializer.Serialize(cart));
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var cart = GetCart();
+        var productIds = cart.Select(c => c.ProductId).ToList();
+        var variantIds = cart.Where(c => c.ProductVariantId.HasValue).Select(c => c.ProductVariantId!.Value).ToList();
+
+        var products = await _context.Products.Where(p => productIds.Contains(p.Id))
+            .ToDictionaryAsync(p => p.Id);
+        var variants = await _context.ProductVariants.Where(v => variantIds.Contains(v.Id))
+            .ToDictionaryAsync(v => v.Id);
+
+        var items = cart.Select(c => new CartItemViewModel
+        {
+            Item = c,
+            Product = products.ContainsKey(c.ProductId) ? products[c.ProductId] : null,
+            ProductVariant = c.ProductVariantId.HasValue && variants.ContainsKey(c.ProductVariantId.Value)
+                ? variants[c.ProductVariantId.Value]
+                : null
+        }).ToList();
+
+        var vm = new CartViewModel
+        {
+            Items = items,
+            Total = cart.Sum(i => i.Price)
+        };
+
+        return View(vm);
+    }
+
+    [HttpPost]
+    public IActionResult Add(int productId, int? productVariantId, decimal price)
+    {
+        var cart = GetCart();
+        cart.Add(new OrderItem { ProductId = productId, ProductVariantId = productVariantId, Price = price });
+        SaveCart(cart);
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    public IActionResult Remove(int index)
+    {
+        var cart = GetCart();
+        if (index >= 0 && index < cart.Count)
+        {
+            cart.RemoveAt(index);
+            SaveCart(cart);
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
+    [Authorize]
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Checkout()
+    {
+        var cart = GetCart();
+        if (!cart.Any())
+        {
+            return RedirectToAction(nameof(Index));
+        }
+
+        var order = new Order
+        {
+            UserId = User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty,
+            Items = cart,
+            Total = cart.Sum(i => i.Price),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        _context.Orders.Add(order);
+        await _context.SaveChangesAsync();
+        HttpContext.Session.Remove(CartSessionKey);
+        return RedirectToAction("Details", "Orders", new { id = order.Id });
+    }
+}

--- a/CloudCityCenter/Models/ViewModels/CartViewModel.cs
+++ b/CloudCityCenter/Models/ViewModels/CartViewModel.cs
@@ -1,0 +1,14 @@
+namespace CloudCityCenter.Models.ViewModels;
+
+public class CartItemViewModel
+{
+    public OrderItem Item { get; set; } = new();
+    public Product? Product { get; set; }
+    public ProductVariant? ProductVariant { get; set; }
+}
+
+public class CartViewModel
+{
+    public List<CartItemViewModel> Items { get; set; } = new();
+    public decimal Total { get; set; }
+}

--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -30,6 +30,14 @@ builder.Services.AddDefaultIdentity<IdentityUser>(options =>
     options.SignIn.RequireConfirmedAccount = false)
     .AddEntityFrameworkStores<ApplicationDbContext>();
 
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession(options =>
+{
+    options.IdleTimeout = TimeSpan.FromHours(1);
+    options.Cookie.HttpOnly = true;
+    options.Cookie.IsEssential = true;
+});
+
 var app = builder.Build();
 
 if (args.Any(a => a == "--seed" || a.StartsWith("--seed-admin=")))
@@ -85,6 +93,8 @@ app.UseStaticFiles();
 
 app.UseRequestLocalization(localizationOptions);
 app.UseRouting();
+
+app.UseSession();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/CloudCityCenter/Views/Cart/Index.cshtml
+++ b/CloudCityCenter/Views/Cart/Index.cshtml
@@ -1,0 +1,47 @@
+@model CloudCityCenter.Models.ViewModels.CartViewModel
+@{
+    ViewData["Title"] = "Cart";
+}
+
+<h1>Cart</h1>
+
+@if (Model.Items.Any())
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Product</th>
+                <th>Variant</th>
+                <th>Price</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @for (int i = 0; i < Model.Items.Count; i++)
+        {
+            var item = Model.Items[i];
+            <tr>
+                <td>@item.Product?.Name</td>
+                <td>@item.ProductVariant?.Name</td>
+                <td>@item.Item.Price.ToString("C")</td>
+                <td>
+                    <form asp-action="Remove" method="post">
+                        <input type="hidden" name="index" value="@i" />
+                        <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+                    </form>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+    <div class="text-end">
+        <strong>Total: @Model.Total.ToString("C")</strong>
+    </div>
+    <form asp-action="Checkout" method="post" class="text-end">
+        <button type="submit" class="btn btn-primary">Checkout</button>
+    </form>
+}
+else
+{
+    <p>Your cart is empty.</p>
+}

--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+@using Microsoft.AspNetCore.Http
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -8,6 +9,7 @@
     <title>@ViewData["Title"] - CloudCityCenter</title>
     <link rel="icon" type="image/png" href="~/images/logo.png">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/CloudCityCenter.styles.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/site.css" />
@@ -19,6 +21,13 @@
 <body>
     @{
         var currentController = ViewContext.RouteData.Values["controller"]?.ToString();
+        var cartJson = Context.Session.GetString("Cart");
+        var cartCount = 0;
+        if (!string.IsNullOrEmpty(cartJson))
+        {
+            var cartItems = System.Text.Json.JsonSerializer.Deserialize<List<CloudCityCenter.Models.OrderItem>>(cartJson);
+            cartCount = cartItems?.Count ?? 0;
+        }
     }
     <header>
         <nav class="navbar navbar-expand-md navbar-light bg-white mb-3">
@@ -74,6 +83,15 @@
                        }
                    </ul>
                    <ul class="navbar-nav">
+                       <li class="nav-item position-relative">
+                           <a class="nav-link" asp-controller="Cart" asp-action="Index">
+                               <i class="bi bi-cart"></i>
+                               @if (cartCount > 0)
+                               {
+                                   <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">@cartCount</span>
+                               }
+                           </a>
+                       </li>
                        @if (User.Identity?.IsAuthenticated ?? false)
                        {
                             <li class="nav-item">


### PR DESCRIPTION
## Summary
- introduce CartController with session-backed add, remove, and checkout actions
- render cart items and totals with new Cart view and viewmodels
- display cart icon with item count in layout and enable session support

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f75b62f8832b846c76c33893b7af