### PR TITLE
Refactor seeding to use existing scope

### DIFF
--- a/CloudCityCenter/Data/SeedData.cs
+++ b/CloudCityCenter/Data/SeedData.cs
@@ -14,10 +14,8 @@ public static class SeedData
 {
     public static async Task RunAsync(IServiceProvider serviceProvider, string? adminEmail = null)
     {
-        using var scope = serviceProvider.CreateScope();
-        var services = scope.ServiceProvider;
-        var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
-        var userManager = services.GetRequiredService<UserManager<IdentityUser>>();
+        var roleManager = serviceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        var userManager = serviceProvider.GetRequiredService<UserManager<IdentityUser>>();
 
         string[] roles = { "Admin", "Manager", "Customer" };
         foreach (var role in roles)

--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -43,14 +43,14 @@ var app = builder.Build();
 if (args.Any(a => a == "--seed" || a.StartsWith("--seed-admin=")))
 {
     using var scope = app.Services.CreateScope();
-    var services = scope.ServiceProvider;
-    var context = services.GetRequiredService<ApplicationDbContext>();
+    var serviceProvider = scope.ServiceProvider;
+    var context = serviceProvider.GetRequiredService<ApplicationDbContext>();
     await context.Database.MigrateAsync();
 
     var adminArg = args.FirstOrDefault(a => a.StartsWith("--seed-admin="));
     var adminEmail = adminArg?.Split('=', 2)[1];
 
-    await SeedData.RunAsync(services, adminEmail);
+    await SeedData.RunAsync(serviceProvider, adminEmail);
 
     if (args.Contains("--seed"))
     {


### PR DESCRIPTION
## Summary
- Simplify SeedData.RunAsync to use provided service provider without creating a new scope
- Pass scoped service provider from Program when seeding to avoid nested scopes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8113fe010832b92b4e88aef20cde4