### PR TITLE
Add trial flow and plan links

### DIFF
--- a/CloudCityCenter/Controllers/TrialsController.cs
+++ b/CloudCityCenter/Controllers/TrialsController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace CloudCityCenter.Controllers;
+
+/// <summary>
+/// Handles the free trial flow for products.
+/// </summary>
+[Route("[controller]")]
+public class TrialsController : Controller
+{
+    /// <summary>
+    /// Starts a trial for the selected plan.
+    /// </summary>
+    [HttpGet("Start")]
+    public IActionResult Start(string? plan)
+    {
+        if (string.IsNullOrWhiteSpace(plan))
+        {
+            return BadRequest();
+        }
+
+        return View(model: plan);
+    }
+}

--- a/CloudCityCenter/Views/Servers/Index.cshtml
+++ b/CloudCityCenter/Views/Servers/Index.cshtml
@@ -40,7 +40,11 @@
             <li><strong>Location:</strong> Germany</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="DS1-E3"
+             data-plan="DS1-E3"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -65,7 +69,11 @@
             <li><strong>Location:</strong> Netherlands</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="DS2-E5"
+             data-plan="DS2-E5"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -90,7 +98,11 @@
             <li><strong>Location:</strong> France</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="DS3-Ryzen"
+             data-plan="DS3-Ryzen"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -115,7 +127,11 @@
             <li><strong>Location:</strong> Finland</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="DS4-EPYC"
+             data-plan="DS4-EPYC"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -140,7 +156,11 @@
             <li><strong>Location:</strong> USA</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="DS5-Storage"
+             data-plan="DS5-Storage"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -165,11 +185,30 @@
             <li><strong>Location:</strong> Singapore</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="DS6-HighMem"
+             data-plan="DS6-HighMem"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
 
   </div>
 </section>
+
+@section Scripts {
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('.plan-btn').forEach(function (btn) {
+                btn.addEventListener('click', function (e) {
+                    const plan = this.dataset.plan;
+                    if (!confirm(`Start free trial for ${plan}?`)) {
+                        e.preventDefault();
+                    }
+                });
+            });
+        });
+    </script>
+}
 

--- a/CloudCityCenter/Views/Trials/Start.cshtml
+++ b/CloudCityCenter/Views/Trials/Start.cshtml
@@ -1,0 +1,11 @@
+@model string
+
+@{
+    ViewData["Title"] = "Start Trial";
+}
+
+<section class="container py-4">
+    <h1 class="mb-3">Start Free Trial</h1>
+    <p class="mb-4">You selected plan <strong>@Model</strong>. Complete the registration form to begin your trial.</p>
+    <!-- TODO: Registration form implementation -->
+</section>

--- a/CloudCityCenter/Views/VPS/Index.cshtml
+++ b/CloudCityCenter/Views/VPS/Index.cshtml
@@ -41,7 +41,11 @@
             <li><strong>Location:</strong> Germany | Poland | France</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="VPS1-1-20"
+             data-plan="VPS1-1-20"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -66,7 +70,11 @@
             <li><strong>Location:</strong> Germany | Poland | France</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="VPS2-2-20"
+             data-plan="VPS2-2-20"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -91,7 +99,11 @@
             <li><strong>Location:</strong> Germany | Poland | France | Netherlands</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="VPS3-4-40"
+             data-plan="VPS3-4-40"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -116,7 +128,11 @@
             <li><strong>Location:</strong> Germany | Poland | France | Netherlands | Singapore | USA</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="VPS4-4-80"
+             data-plan="VPS4-4-80"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -141,7 +157,11 @@
             <li><strong>Location:</strong> Germany | Poland | France | Netherlands | Singapore | USA</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="VPS5-4-80"
+             data-plan="VPS5-4-80"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
@@ -166,10 +186,29 @@
             <li><strong>Location:</strong> Germany | Poland | France | Netherlands | Singapore | USA</li>
           </ul>
 
-          <a href="#" class="btn btn-dark plan-btn">Start Free Trial</a>
+          <a asp-controller="Trials"
+             asp-action="Start"
+             asp-route-plan="VPS6-6-100"
+             data-plan="VPS6-6-100"
+             class="btn btn-dark plan-btn">Start Free Trial</a>
         </div>
       </div>
     </div>
 
   </div>
 </section>
+
+@section Scripts {
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('.plan-btn').forEach(function (btn) {
+                btn.addEventListener('click', function (e) {
+                    const plan = this.dataset.plan;
+                    if (!confirm(`Start free trial for ${plan}?`)) {
+                        e.preventDefault();
+                    }
+                });
+            });
+        });
+    </script>
+}


### PR DESCRIPTION
## Summary
- link server and VPS plans to a new TrialsController Start action
- implement TrialsController and starter view to handle selected plan
- add client-side confirmation when starting a free trial

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b815f0ea84832b87c291c11bcd7478