### PR TITLE
Add VPS product type and dynamic VPS listing

### DIFF
--- a/CloudCityCenter/Controllers/VPSController.cs
+++ b/CloudCityCenter/Controllers/VPSController.cs
@@ -1,9 +1,41 @@
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using CloudCityCenter.Models.ViewModels;
+
+namespace CloudCityCenter.Controllers;
 
 public class VPSController : Controller
 {
-    public IActionResult Index()
+    private readonly ApplicationDbContext _context;
+
+    public VPSController(ApplicationDbContext context)
     {
-        return View();
+        _context = context;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var products = await _context.Products
+            .Where(p => p.Type == ProductType.VPS && p.IsPublished)
+            .Select(p => new ProductCardVm
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Slug = p.Slug,
+                PricePerMonth = p.PricePerMonth,
+                ImageUrl = p.ImageUrl,
+                TopFeatures = p.Features
+                    .OrderBy(f => f.Id)
+                    .Select(f => string.IsNullOrWhiteSpace(f.Value) ? f.Name : $"{f.Name}: {f.Value}")
+                    .ToList()
+            })
+            .ToListAsync();
+
+        return View(products);
     }
 }
+

--- a/CloudCityCenter/Data/SeedData.cs
+++ b/CloudCityCenter/Data/SeedData.cs
@@ -140,6 +140,186 @@ public static class SeedData
             },
             new()
             {
+                Name = "VPS1-1-20",
+                Slug = "vps1-1-20",
+                Location = "Germany",
+                PricePerMonth = 10,
+                Configuration = "Intel 1 Core, 1GB RAM, 20GB SSD",
+                IsAvailable = true,
+                IsPublished = true,
+                ImageUrl = "/images/vps1.png",
+                Type = ProductType.VPS,
+                Variants = new List<ProductVariant>
+                {
+                    new()
+                    {
+                        Name = "Monthly",
+                        Price = 10,
+                        BillingPeriod = BillingPeriod.Monthly
+                    }
+                },
+                Features = new List<ProductFeature>
+                {
+                    new() { Name = "CPU", Value = "Intel 1 Core" },
+                    new() { Name = "RAM", Value = "1GB" },
+                    new() { Name = "Storage", Value = "20GB SSD" },
+                    new() { Name = "Network", Value = "100Mbps Bandwidth" },
+                    new() { Name = "IPv4", Value = "1" },
+                    new() { Name = "Location", Value = "Germany | Poland | France" }
+                }
+            },
+            new()
+            {
+                Name = "VPS2-2-20",
+                Slug = "vps2-2-20",
+                Location = "Germany",
+                PricePerMonth = 12,
+                Configuration = "Intel 2 Cores, 2GB RAM, 20GB SSD",
+                IsAvailable = true,
+                IsPublished = true,
+                ImageUrl = "/images/vps2.png",
+                Type = ProductType.VPS,
+                Variants = new List<ProductVariant>
+                {
+                    new()
+                    {
+                        Name = "Monthly",
+                        Price = 12,
+                        BillingPeriod = BillingPeriod.Monthly
+                    }
+                },
+                Features = new List<ProductFeature>
+                {
+                    new() { Name = "CPU", Value = "Intel 2 Cores" },
+                    new() { Name = "RAM", Value = "2GB" },
+                    new() { Name = "Storage", Value = "20GB SSD" },
+                    new() { Name = "Network", Value = "250Mbps Bandwidth" },
+                    new() { Name = "IPv4", Value = "1" },
+                    new() { Name = "Location", Value = "Germany | Poland | France" }
+                }
+            },
+            new()
+            {
+                Name = "VPS3-4-40",
+                Slug = "vps3-4-40",
+                Location = "Germany",
+                PricePerMonth = 19,
+                Configuration = "AMD | Intel 4 Cores, 4GB RAM, 40GB SSD",
+                IsAvailable = true,
+                IsPublished = true,
+                ImageUrl = "/images/vps3.png",
+                Type = ProductType.VPS,
+                Variants = new List<ProductVariant>
+                {
+                    new()
+                    {
+                        Name = "Monthly",
+                        Price = 19,
+                        BillingPeriod = BillingPeriod.Monthly
+                    }
+                },
+                Features = new List<ProductFeature>
+                {
+                    new() { Name = "CPU", Value = "AMD | Intel 4 Cores" },
+                    new() { Name = "RAM", Value = "4GB" },
+                    new() { Name = "Storage", Value = "40GB SSD" },
+                    new() { Name = "Network", Value = "250Mbps Bandwidth" },
+                    new() { Name = "IPv4", Value = "1" },
+                    new() { Name = "Location", Value = "Germany | Poland | France | Netherlands" }
+                }
+            },
+            new()
+            {
+                Name = "VPS4-4-80",
+                Slug = "vps4-4-80",
+                Location = "Germany",
+                PricePerMonth = 24,
+                Configuration = "AMD | Intel 4 Cores, 4GB RAM, 80GB SSD",
+                IsAvailable = true,
+                IsPublished = true,
+                ImageUrl = "/images/vps4.png",
+                Type = ProductType.VPS,
+                Variants = new List<ProductVariant>
+                {
+                    new()
+                    {
+                        Name = "Monthly",
+                        Price = 24,
+                        BillingPeriod = BillingPeriod.Monthly
+                    }
+                },
+                Features = new List<ProductFeature>
+                {
+                    new() { Name = "CPU", Value = "AMD | Intel 4 Cores" },
+                    new() { Name = "RAM", Value = "4GB" },
+                    new() { Name = "Storage", Value = "80GB SSD" },
+                    new() { Name = "Network", Value = "500Mbps Bandwidth" },
+                    new() { Name = "IPv4", Value = "1" },
+                    new() { Name = "Location", Value = "Germany | Poland | France | Netherlands | Singapore | USA" }
+                }
+            },
+            new()
+            {
+                Name = "VPS5-4-80",
+                Slug = "vps5-4-80",
+                Location = "Germany",
+                PricePerMonth = 28,
+                Configuration = "AMD | Intel 4 Cores, 4GB RAM, 80GB SSD",
+                IsAvailable = true,
+                IsPublished = true,
+                ImageUrl = "/images/vps5.png",
+                Type = ProductType.VPS,
+                Variants = new List<ProductVariant>
+                {
+                    new()
+                    {
+                        Name = "Monthly",
+                        Price = 28,
+                        BillingPeriod = BillingPeriod.Monthly
+                    }
+                },
+                Features = new List<ProductFeature>
+                {
+                    new() { Name = "CPU", Value = "AMD | Intel 4 Cores" },
+                    new() { Name = "RAM", Value = "4GB" },
+                    new() { Name = "Storage", Value = "80GB SSD" },
+                    new() { Name = "Network", Value = "1000Mbps Bandwidth" },
+                    new() { Name = "IPv4", Value = "1" },
+                    new() { Name = "Location", Value = "Germany | Poland | France | Netherlands | Singapore | USA" }
+                }
+            },
+            new()
+            {
+                Name = "VPS6-6-100",
+                Slug = "vps6-6-100",
+                Location = "Germany",
+                PricePerMonth = 35,
+                Configuration = "AMD | Intel 4 Cores, 6GB RAM, 100GB SSD",
+                IsAvailable = true,
+                IsPublished = true,
+                ImageUrl = "/images/vps6.png",
+                Type = ProductType.VPS,
+                Variants = new List<ProductVariant>
+                {
+                    new()
+                    {
+                        Name = "Monthly",
+                        Price = 35,
+                        BillingPeriod = BillingPeriod.Monthly
+                    }
+                },
+                Features = new List<ProductFeature>
+                {
+                    new() { Name = "CPU", Value = "AMD | Intel 4 Cores" },
+                    new() { Name = "RAM", Value = "6GB" },
+                    new() { Name = "Storage", Value = "100GB SSD" },
+                    new() { Name = "Network", Value = "1000Mbps Bandwidth" },
+                    new() { Name = "IPv4", Value = "1" },
+                    new() { Name = "Location", Value = "Germany | Poland | France | Netherlands | Singapore | USA" }
+                }
+            },
+            new()
+            {
                 Name = "Starter Website",
                 Slug = "starter-website",
                 Location = "US",

--- a/CloudCityCenter/Models/ProductType.cs
+++ b/CloudCityCenter/Models/ProductType.cs
@@ -4,5 +4,6 @@ public enum ProductType
 {
     DedicatedServer,
     Hosting,
-    Website
+    Website,
+    VPS
 }

--- a/CloudCityCenter/Views/VPS/Index.cshtml
+++ b/CloudCityCenter/Views/VPS/Index.cshtml
@@ -1,3 +1,4 @@
+@model IEnumerable<CloudCityCenter.Models.ViewModels.ProductCardVm>
 @{
     ViewData["Title"] = "VPS Hosting";
 }
@@ -5,210 +6,27 @@
 <section class="container py-4">
     <h1 class="mb-3">VPS Hosting</h1>
     <p class="text-muted">
-     VPS (Virtual Private Server) is a virtual dedicated server that combines the advantages of renting a physical server with the convenience of cloud technologies. Each customer receives their own isolated space with dedicated resources — processor, RAM, disk space, and root access.
+        VPS (Virtual Private Server) is a virtual dedicated server that combines the advantages of renting a physical server with the convenience of cloud technologies. Each customer receives their own isolated space with dedicated resources — processor, RAM, disk space, and root access.
     </p>
-
-
 
     <h5>What you get</h5>
     <ul>
-        <li>Dedicated resources & full root access</li>
+        <li>Dedicated resources &amp; full root access</li>
         <li>SSD storage, enterprise-grade hardware</li>
         <li>24/7 expert support</li>
     </ul>
 </section>
 
 <section class="container my-5">
-  <div class="row g-4">
-
-    <!-- VPS 1 -->
-    <div class="col-12 col-md-6 col-lg-4">
-      <div class="plan-card shadow-lg">
-        <div class="plan-media">
-          <img src="/images/vps1.png" alt="VPS1-1-20">
-        </div>
-
-        <div class="plan-body">
-          <h3 class="plan-title">VPS1‑1‑20</h3>
-          <p class="plan-price">Starting at <span>$10</span>/month</p>
-
-          <ul class="plan-specs">
-            <li><strong>CPU:</strong> Intel 1 Core</li>
-            <li><strong>RAM:</strong> 1GB</li>
-            <li><strong>Storage:</strong> 20GB SSD</li>
-            <li><strong>Network:</strong> 100Mbps Bandwidth</li>
-            <li><strong>IPv4:</strong> 1</li>
-            <li><strong>Location:</strong> Germany | Poland | France</li>
-          </ul>
-
-          <a asp-controller="Trials"
-             asp-action="Start"
-             asp-route-plan="VPS1-1-20"
-             data-plan="VPS1-1-20"
-             class="btn btn-dark plan-btn">Start Free Trial</a>
-        </div>
-      </div>
+    <div class="row row-cols-1 row-cols-md-3 g-4">
+        @foreach (var item in Model)
+        {
+            <div class="col">
+                <div class="card h-100">
+                    @await Html.PartialAsync("_ProductCard", item)
+                </div>
+            </div>
+        }
     </div>
-
-    <!-- VPS 2 -->
-    <div class="col-12 col-md-6 col-lg-4">
-      <div class="plan-card shadow-lg">
-        <div class="plan-media">
-          <img src="/images/vps2.png" alt="VPS2-2-20">
-        </div>
-
-        <div class="plan-body">
-          <h3 class="plan-title">VPS2‑2‑20</h3>
-          <p class="plan-price">Starting at <span>$12</span>/month</p>
-
-          <ul class="plan-specs">
-            <li><strong>CPU:</strong> Intel 2 Cores</li>
-            <li><strong>RAM:</strong> 2GB</li>
-            <li><strong>Storage:</strong> 20GB SSD</li>
-            <li><strong>Network:</strong> 250Mbps Bandwidth</li>
-            <li><strong>IPv4:</strong> 1</li>
-            <li><strong>Location:</strong> Germany | Poland | France</li>
-          </ul>
-
-          <a asp-controller="Trials"
-             asp-action="Start"
-             asp-route-plan="VPS2-2-20"
-             data-plan="VPS2-2-20"
-             class="btn btn-dark plan-btn">Start Free Trial</a>
-        </div>
-      </div>
-    </div>
-
-    <!-- VPS 3 -->
-    <div class="col-12 col-md-6 col-lg-4">
-      <div class="plan-card shadow-lg">
-        <div class="plan-media">
-          <img src="/images/vps3.png" alt="VPS3-4-40">
-        </div>
-
-        <div class="plan-body">
-          <h3 class="plan-title">VPS3‑4‑40</h3>
-          <p class="plan-price">Starting at <span>$19</span>/month</p>
-
-          <ul class="plan-specs">
-            <li><strong>CPU:</strong> AMD | Intel 4 Cores</li>
-            <li><strong>RAM:</strong> 4GB</li>
-            <li><strong>Storage:</strong> 40GB SSD</li>
-            <li><strong>Network:</strong> 250Mbps Bandwidth</li>
-            <li><strong>IPv4:</strong> 1</li>
-            <li><strong>Location:</strong> Germany | Poland | France | Netherlands</li>
-          </ul>
-
-          <a asp-controller="Trials"
-             asp-action="Start"
-             asp-route-plan="VPS3-4-40"
-             data-plan="VPS3-4-40"
-             class="btn btn-dark plan-btn">Start Free Trial</a>
-        </div>
-      </div>
-    </div>
-
-    <!-- VPS 4 -->
-    <div class="col-12 col-md-6 col-lg-4">
-      <div class="plan-card shadow-lg">
-        <div class="plan-media">
-          <img src="/images/vps4.png" alt="VPS4-4-80">
-        </div>
-
-        <div class="plan-body">
-          <h3 class="plan-title">VPS4‑4‑80</h3>
-          <p class="plan-price">Starting at <span>$24</span>/month</p>
-
-          <ul class="plan-specs">
-            <li><strong>CPU:</strong> AMD | Intel 4 Cores</li>
-            <li><strong>RAM:</strong> 4GB</li>
-            <li><strong>Storage:</strong> 80GB SSD</li>
-            <li><strong>Network:</strong> 500Mbps Bandwidth</li>
-            <li><strong>IPv4:</strong> 1</li>
-            <li><strong>Location:</strong> Germany | Poland | France | Netherlands | Singapore | USA</li>
-          </ul>
-
-          <a asp-controller="Trials"
-             asp-action="Start"
-             asp-route-plan="VPS4-4-80"
-             data-plan="VPS4-4-80"
-             class="btn btn-dark plan-btn">Start Free Trial</a>
-        </div>
-      </div>
-    </div>
-
-    <!-- VPS 5 -->
-    <div class="col-12 col-md-6 col-lg-4">
-      <div class="plan-card shadow-lg">
-        <div class="plan-media">
-          <img src="/images/vps5.png" alt="VPS5-4-80">
-        </div>
-
-        <div class="plan-body">
-          <h3 class="plan-title">VPS5‑4‑80</h3>
-          <p class="plan-price">Starting at <span>$28</span>/month</p>
-
-          <ul class="plan-specs">
-            <li><strong>CPU:</strong> AMD | Intel 4 Cores</li>
-            <li><strong>RAM:</strong> 4GB</li>
-            <li><strong>Storage:</strong> 80GB SSD</li>
-            <li><strong>Network:</strong> 1000Mbps Bandwidth</li>
-            <li><strong>IPv4:</strong> 1</li>
-            <li><strong>Location:</strong> Germany | Poland | France | Netherlands | Singapore | USA</li>
-          </ul>
-
-          <a asp-controller="Trials"
-             asp-action="Start"
-             asp-route-plan="VPS5-4-80"
-             data-plan="VPS5-4-80"
-             class="btn btn-dark plan-btn">Start Free Trial</a>
-        </div>
-      </div>
-    </div>
-
-    <!-- VPS 6 -->
-    <div class="col-12 col-md-6 col-lg-4">
-      <div class="plan-card shadow-lg">
-        <div class="plan-media">
-          <img src="/images/vps6.png" alt="VPS6-6-100">
-        </div>
-
-        <div class="plan-body">
-          <h3 class="plan-title">VPS6‑6‑100</h3>
-          <p class="plan-price">Starting at <span>$35</span>/month</p>
-
-          <ul class="plan-specs">
-            <li><strong>CPU:</strong> AMD | Intel 4 Cores</li>
-            <li><strong>RAM:</strong> 6GB</li>
-            <li><strong>Storage:</strong> 100GB SSD</li>
-            <li><strong>Network:</strong> 1000Mbps Bandwidth</li>
-            <li><strong>IPv4:</strong> 1</li>
-            <li><strong>Location:</strong> Germany | Poland | France | Netherlands | Singapore | USA</li>
-          </ul>
-
-          <a asp-controller="Trials"
-             asp-action="Start"
-             asp-route-plan="VPS6-6-100"
-             data-plan="VPS6-6-100"
-             class="btn btn-dark plan-btn">Start Free Trial</a>
-        </div>
-      </div>
-    </div>
-
-  </div>
 </section>
 
-@section Scripts {
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            document.querySelectorAll('.plan-btn').forEach(function (btn) {
-                btn.addEventListener('click', function (e) {
-                    const plan = this.dataset.plan;
-                    if (!confirm(`Start free trial for ${plan}?`)) {
-                        e.preventDefault();
-                    }
-                });
-            });
-        });
-    </script>
-}


### PR DESCRIPTION
## Summary
- add VPS to `ProductType`
- seed complete set of VPS plans
- populate VPS page from database using `ProductCardVm`

## Testing
- `dotnet build`
- `dotnet test -v n`


------
https://chatgpt.com/codex/tasks/task_e_68b827a250c8832bbf8a47c53e8982ab