### PR TITLE
Add VPN products and controller logic

### DIFF
--- a/CloudCityCenter/Controllers/VPNController.cs
+++ b/CloudCityCenter/Controllers/VPNController.cs
@@ -1,6 +1,41 @@
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using CloudCityCenter.Models.ViewModels;
+
+namespace CloudCityCenter.Controllers;
 
 public class VPNController : Controller
 {
-    public IActionResult Index() => View();
+    private readonly ApplicationDbContext _context;
+
+    public VPNController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var vpnProducts = await _context.Products
+            .Where(p => p.Type == ProductType.VPN && p.IsPublished)
+            .Select(p => new ProductCardVm
+            {
+                Id = p.Id,
+                Name = p.Name,
+                Slug = p.Slug,
+                PricePerMonth = p.PricePerMonth,
+                ImageUrl = p.ImageUrl,
+                TopFeatures = p.Features
+                    .OrderBy(f => f.Id)
+                    .Select(f => string.IsNullOrWhiteSpace(f.Value) ? f.Name : $"{f.Name}: {f.Value}")
+                    .Take(3)
+                    .ToList(),
+            })
+            .ToListAsync();
+
+        return View(vpnProducts);
+    }
 }

--- a/CloudCityCenter/Data/SeedData.cs
+++ b/CloudCityCenter/Data/SeedData.cs
@@ -320,6 +320,60 @@ public static class SeedData
             },
             new()
             {
+                Name = "VPN for a network",
+                Slug = "vpn-network",
+                Location = "Global",
+                PricePerMonth = 80,
+                Configuration = "Site-to-site VPN service",
+                IsAvailable = true,
+                IsPublished = true,
+                ImageUrl = "/images/vpn-network.png",
+                Type = ProductType.VPN,
+                Variants = new List<ProductVariant>
+                {
+                    new()
+                    {
+                        Name = "Monthly",
+                        Price = 80,
+                        BillingPeriod = BillingPeriod.Monthly
+                    }
+                },
+                Features = new List<ProductFeature>
+                {
+                    new() { Name = "Devices", Value = "Up to 50" },
+                    new() { Name = "Traffic", Value = "Unlimited" },
+                    new() { Name = "Support", Value = "24/7" }
+                }
+            },
+            new()
+            {
+                Name = "VPN for a device",
+                Slug = "vpn-device",
+                Location = "Global",
+                PricePerMonth = 25,
+                Configuration = "Single device VPN",
+                IsAvailable = true,
+                IsPublished = true,
+                ImageUrl = "/images/vpn-device.png",
+                Type = ProductType.VPN,
+                Variants = new List<ProductVariant>
+                {
+                    new()
+                    {
+                        Name = "Monthly",
+                        Price = 25,
+                        BillingPeriod = BillingPeriod.Monthly
+                    }
+                },
+                Features = new List<ProductFeature>
+                {
+                    new() { Name = "Traffic", Value = "Unlimited" },
+                    new() { Name = "Servers", Value = "50+ Countries" },
+                    new() { Name = "Encryption", Value = "AES-256" }
+                }
+            },
+            new()
+            {
                 Name = "Starter Website",
                 Slug = "starter-website",
                 Location = "US",

--- a/CloudCityCenter/Models/ProductType.cs
+++ b/CloudCityCenter/Models/ProductType.cs
@@ -5,5 +5,6 @@ public enum ProductType
     DedicatedServer,
     Hosting,
     Website,
-    VPS
+    VPS,
+    VPN
 }

--- a/CloudCityCenter/Views/VPN/Index.cshtml
+++ b/CloudCityCenter/Views/VPN/Index.cshtml
@@ -1,3 +1,4 @@
+@model IEnumerable<CloudCityCenter.Models.ViewModels.ProductCardVm>
 @{
     ViewData["Title"] = "VPN Tunneling";
 }
@@ -26,36 +27,17 @@
   </div>
 </section>
 
-
 <section class="container py-5">
-    <div class="row g-4 justify-content-center">
-
-        <!-- VPN for a Network -->
-        <div class="col-12 col-sm-6 col-md-4">
-            <div class="card h-100 shadow text-center">
-                <img src="/images/vpn-network.png" class="card-img-top" alt="VPN for a network">
-                <div class="card-body">
-                    <h5 class="fw-semibold">VPN for a network</h5>
-                    <p class="text-muted">80.00$</p>
-                    <a href="#" class="btn btn-dark">Добавить в корзину</a>
+    <div class="row row-cols-1 row-cols-md-3 g-4 justify-content-center">
+        @foreach (var item in Model)
+        {
+            <div class="col">
+                <div class="card h-100 shadow text-center">
+                    @await Html.PartialAsync("_ProductCard", item)
                 </div>
             </div>
-        </div>
-
-        <!-- VPN for a Device -->
-        <div class="col-12 col-sm-6 col-md-4">
-            <div class="card h-100 shadow text-center">
-                <img src="/images/vpn-device.png" class="card-img-top" alt="VPN for a device">
-                <div class="card-body">
-                    <h5 class="fw-semibold">VPN for a device</h5>
-                    <p class="text-muted">25.00$</p>
-                    <a href="#" class="btn btn-dark">Добавить в корзину</a>
-                </div>
-            </div>
-        </div>
-
+        }
     </div>
-
 </section>
 
 <!-- Payments section -->


### PR DESCRIPTION
## Summary
- add VPN enum value and seed two VPN products with features
- implement VPNController to load VPN product cards
- render VPN products dynamically in view using shared product card partial

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b836289ef8832bb2bab7c3a5950b7b