### PR TITLE
Use in-memory database fallback

### DIFF
--- a/CloudCityCenter/CloudCityCenter.csproj
+++ b/CloudCityCenter/CloudCityCenter.csproj
@@ -11,6 +11,7 @@
       <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.6" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- Add conditional database configuration to use in-memory store when no connection string is supplied
- Skip migrations when using non-relational providers and ensure database creation
- Reference EF Core InMemory provider package

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet run --project CloudCityCenter/CloudCityCenter.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68b853c0b23c832b9e929cf8ef0bdffa