### PR TITLE
Replace cart table with Bootstrap card layout

### DIFF
--- a/CloudCityCenter/Views/Cart/Index.cshtml
+++ b/CloudCityCenter/Views/Cart/Index.cshtml
@@ -12,34 +12,31 @@
 
 @if (Model.Items.Any())
 {
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Product</th>
-                <th>Variant</th>
-                <th>Price</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-        @for (int i = 0; i < Model.Items.Count; i++)
-        {
-            var item = Model.Items[i];
-            <tr>
-                <td>@item.Product?.Name</td>
-                <td>@item.ProductVariant?.Name</td>
-                <td>@item.Item.Price.ToString("C")</td>
-                <td>
-                    <form asp-action="Remove" method="post">
-                        @Html.AntiForgeryToken()
-                        <input type="hidden" name="index" value="@i" />
-                        <button type="submit" class="btn btn-sm btn-danger">Remove</button>
-                    </form>
-                </td>
-            </tr>
-        }
-        </tbody>
-    </table>
+    @for (int i = 0; i < Model.Items.Count; i++)
+    {
+        var item = Model.Items[i];
+        <div class="card mb-3">
+            <img src="@item.Product?.ImageUrl" alt="@item.Product?.Name" class="card-img-top" onerror="this.onerror=null;this.src='https://via.placeholder.com/300x200?text=No+Image';" />
+            <div class="card-body">
+                <div class="row">
+                    <div class="col">
+                        <h5 class="card-title mb-1">@item.Product?.Name</h5>
+                        <p class="card-text"><small class="text-muted">@item.ProductVariant?.Name</small></p>
+                    </div>
+                    <div class="col-auto text-end">
+                        <p class="card-text fw-semibold mb-0">@item.Item.Price.ToString("C")</p>
+                    </div>
+                </div>
+            </div>
+            <div class="card-footer text-end">
+                <form asp-action="Remove" method="post">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="index" value="@i" />
+                    <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+                </form>
+            </div>
+        </div>
+    }
     <div class="text-end">
         <strong>Total: @Model.Total.ToString("C")</strong>
     </div>


### PR DESCRIPTION
## Summary
- Switch cart view from table to Bootstrap cards
- Show product images with placeholder fallback
- Use card layout to display item details and remove button

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b856501884832ba94e91c6c9dfdfcb