### PR TITLE
Add clear cart option and navigation buttons

### DIFF
--- a/CloudCityCenter/Controllers/CartController.cs
+++ b/CloudCityCenter/Controllers/CartController.cs
@@ -143,6 +143,14 @@ public class CartController : Controller
         return RedirectToAction(nameof(Index));
     }
 
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public IActionResult Clear()
+    {
+        HttpContext.Session.Remove(CartSessionKey);
+        return RedirectToAction(nameof(Index));
+    }
+
     [Authorize]
     [HttpPost]
     [ValidateAntiForgeryToken]

--- a/CloudCityCenter/Views/Cart/Index.cshtml
+++ b/CloudCityCenter/Views/Cart/Index.cshtml
@@ -32,11 +32,20 @@
                 <form asp-action="Remove" method="post">
                     @Html.AntiForgeryToken()
                     <input type="hidden" name="index" value="@i" />
-                    <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+                    <button type="submit" class="btn btn-sm btn-outline-danger" title="Удалить">
+                        <i class="bi bi-trash"></i>
+                    </button>
                 </form>
             </div>
         </div>
     }
+    <div class="d-flex justify-content-between mb-3">
+        <a asp-controller="Servers" asp-action="Index" class="btn btn-outline-primary">Продолжить покупки</a>
+        <form asp-action="Clear" method="post" class="d-inline">
+            @Html.AntiForgeryToken()
+            <button type="submit" class="btn btn-outline-danger">Очистить корзину</button>
+        </form>
+    </div>
     <div class="cart-summary">
         <div class="total">Total: @Model.Total.ToString("C")</div>
         <form asp-action="Checkout" method="post" class="mt-2">


### PR DESCRIPTION
## Summary
- Replace text-based remove button with trash icon and tooltip in cart view
- Add continue shopping and clear cart actions under cart items
- Implement `Clear` action in `CartController` to empty session cart

## Testing
- ⚠️ `dotnet build CloudCityCenter.sln` *(`dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8593c905c832bb52b65893a4409be