### PR TITLE
Use Bootstrap grid for cards and tweak mobile image spacing

### DIFF
--- a/CloudCityCenter/Views/Hosting/Index.cshtml
+++ b/CloudCityCenter/Views/Hosting/Index.cshtml
@@ -32,10 +32,10 @@
         <button type="submit" class="btn btn-success">Add All to Cart</button>
     </form>
     <h2 class="mb-3">Hosting Plans</h2>
-    <div class="row row-cols-1 row-cols-md-3 g-4">
+    <div class="row g-4">
         @foreach (var item in Model.HostingPlans)
         {
-            <div class="col">
+            <div class="col-12 col-md-6">
                 <div class="card h-100">
                     @await Html.PartialAsync("_ProductCard", item)
                 </div>
@@ -46,10 +46,10 @@
 
 <section class="container py-4">
     <h2 class="mb-3">Create Website</h2>
-    <div class="row row-cols-1 row-cols-md-3 g-4">
+    <div class="row g-4">
         @foreach (var item in Model.WebsiteProducts)
         {
-            <div class="col">
+            <div class="col-12 col-md-6">
                 <div class="card h-100">
                     @await Html.PartialAsync("_ProductCard", item)
                 </div>
@@ -60,10 +60,10 @@
 
 <section class="container py-4">
     <h2 class="mb-3">VPS Hosting</h2>
-    <div class="row row-cols-1 row-cols-md-3 g-4">
+    <div class="row g-4">
         @foreach (var item in Model.VpsProducts)
         {
-            <div class="col">
+            <div class="col-12 col-md-6">
                 <div class="card h-100">
                     @await Html.PartialAsync("_ProductCard", item)
                 </div>
@@ -74,10 +74,10 @@
 
 <section class="container py-4">
     <h2 class="mb-3">VPN Tunneling</h2>
-    <div class="row row-cols-1 row-cols-md-3 g-4">
+    <div class="row g-4">
         @foreach (var item in Model.VpnProducts)
         {
-            <div class="col">
+            <div class="col-12 col-md-6">
                 <div class="card h-100">
                     @await Html.PartialAsync("_ProductCard", item)
                 </div>

--- a/CloudCityCenter/Views/Orders/Index.cshtml
+++ b/CloudCityCenter/Views/Orders/Index.cshtml
@@ -9,11 +9,11 @@
     <a asp-action="Create" class="btn btn-primary">Create New</a>
 </p>
 
-<div class="row row-cols-1 row-cols-md-2 g-4">
+<div class="row g-4">
 @foreach (var item in Model)
 {
     var first = item.Items.FirstOrDefault();
-    <div class="col">
+    <div class="col-12 col-md-6">
         <div class="card h-100">
             <img src="@(first?.Product?.ImageUrl ?? "https://via.placeholder.com/300x200?text=Server")" class="card-img-top" alt="@first?.Product?.Name" />
             <div class="card-body">

--- a/CloudCityCenter/Views/Servers/Index.cshtml
+++ b/CloudCityCenter/Views/Servers/Index.cshtml
@@ -19,10 +19,10 @@
 </section>
 
 <section class="container my-5">
-    <div class="row row-cols-1 row-cols-md-3 g-4">
+    <div class="row g-4">
         @foreach (var item in Model)
         {
-            <div class="col">
+            <div class="col-12 col-md-6">
                 <div class="card h-100">
                     @await Html.PartialAsync("_ProductCard", item)
                 </div>

--- a/CloudCityCenter/Views/VPN/Index.cshtml
+++ b/CloudCityCenter/Views/VPN/Index.cshtml
@@ -28,10 +28,10 @@
 </section>
 
 <section class="container py-5">
-    <div class="row row-cols-1 row-cols-md-3 g-4 justify-content-center">
+    <div class="row g-4 justify-content-center">
         @foreach (var item in Model)
         {
-            <div class="col">
+            <div class="col-12 col-md-6">
                 <div class="card h-100 shadow text-center">
                     @await Html.PartialAsync("_ProductCard", item)
                 </div>

--- a/CloudCityCenter/Views/VPS/Index.cshtml
+++ b/CloudCityCenter/Views/VPS/Index.cshtml
@@ -18,10 +18,10 @@
 </section>
 
 <section class="container my-5">
-    <div class="row row-cols-1 row-cols-md-3 g-4">
+    <div class="row g-4">
         @foreach (var item in Model)
         {
-            <div class="col">
+            <div class="col-12 col-md-6">
                 <div class="card h-100">
                     @await Html.PartialAsync("_ProductCard", item)
                 </div>

--- a/CloudCityCenter/wwwroot/css/site.css
+++ b/CloudCityCenter/wwwroot/css/site.css
@@ -346,6 +346,18 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
+@media (max-width: 576px) {
+  .service-item {
+    gap: 20px;
+    margin-bottom: 40px;
+  }
+
+  .service-item img {
+    max-width: 280px;
+    margin: 0 auto 20px;
+  }
+}
+
 .services-button-wrapper {
   text-align: center;
   margin-top: 40px;


### PR DESCRIPTION
## Summary
- display product listings with `row` and `col-12 col-md-6` for responsive two-column cards
- adjust service-section spacing and image size for screens ≤576px

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b85b724e6c832b8da9128c23b564ed