### PR TITLE
Add continue shopping link to empty cart alert

### DIFF
--- a/CloudCityCenter/Views/Cart/Index.cshtml
+++ b/CloudCityCenter/Views/Cart/Index.cshtml
@@ -56,5 +56,7 @@
 }
 else
 {
-    <p>Your cart is empty.</p>
+    <div class="alert alert-info text-center">
+        Your cart is empty. <a asp-controller="Servers" asp-action="Index" class="alert-link">Продолжить покупки</a>
+    </div>
 }


### PR DESCRIPTION
## Summary
- show alert when cart is empty and include a link to continue shopping

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b85c78747c832b9a4593ea3b9a2311