### PR TITLE
feat: add provider selection for DbContext

### DIFF
--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -15,12 +15,20 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddControllersWithViews().AddViewLocalization();
 
-if (string.IsNullOrEmpty(connectionString))
-    builder.Services.AddDbContext<ApplicationDbContext>(opt =>
-        opt.UseInMemoryDatabase("CloudCity"));
-else
-    builder.Services.AddDbContext<ApplicationDbContext>(opt =>
-        opt.UseSqlite(connectionString));
+builder.Services.AddDbContext<ApplicationDbContext>(opt =>
+{
+    if (!string.IsNullOrEmpty(connectionString))
+    {
+        if (connectionString.Contains("Server=", StringComparison.OrdinalIgnoreCase))
+            opt.UseSqlServer(connectionString);
+        else
+            opt.UseSqlite(connectionString);
+    }
+    else
+    {
+        opt.UseInMemoryDatabase("CloudCity");
+    }
+});
 
 builder.Services.AddDefaultIdentity<IdentityUser>(options =>
     options.SignIn.RequireConfirmedAccount = false)

--- a/README.md
+++ b/README.md
@@ -116,10 +116,26 @@ This will create the test user `test@example.com` with password `Pa$$w0rd` and a
 ## 🔗 Изменение строки подключения
 **Changing the connection string**
 
-Строка подключения `DefaultConnection` по умолчанию указывает на LocalDB.  
-The `DefaultConnection` connection string points to LocalDB by default.  
-Вы можете отредактировать её в файле `CloudCityCenter/appsettings.json` или передать значение через переменную окружения:  
-You can edit it in `CloudCityCenter/appsettings.json` or provide it via an environment variable:
+Строка подключения `DefaultConnection` по умолчанию указывает на LocalDB.
+The `DefaultConnection` connection string points to LocalDB by default.
+
+Приложение автоматически выбирает провайдера: если в строке есть `Server=`, будет использован SQL Server, иначе — SQLite. Без строки подключения создаётся временная база в памяти.
+The application automatically selects the provider: if `Server=` is present, SQL Server is used; otherwise SQLite. When no connection string is supplied, an in-memory database is created.
+
+Укажите корректную строку подключения в `CloudCityCenter/appsettings.json`:
+Provide a valid connection string in `CloudCityCenter/appsettings.json`:
+
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=cloudcity.db"
+  }
+}
+```
+
+Или передайте её через переменную окружения:
+Or supply it via an environment variable:
+
 ```bash
 export ConnectionStrings__DefaultConnection="Server=localhost\SQLEXPRESS;Database=master;Trusted_Connection=True;"
 ```


### PR DESCRIPTION
## Summary
- choose database provider based on connection string
- document connection string setup and provider detection

## Testing
- `dotnet build CloudCityCenter/CloudCityCenter.csproj`
- `ConnectionStrings__DefaultConnection="Data Source=cloudcity.db" dotnet run --project CloudCityCenter`
- `ConnectionStrings__DefaultConnection="Server=localhost;Database=CloudCity;User Id=sa;Password=Password123;TrustServerCertificate=True;" dotnet run --project CloudCityCenter` *(fails: SQL Server connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68b960652c10832bb546b5a5c3e6ab1f