### PR TITLE
Guard against missing DB connection outside development

### DIFF
--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -8,6 +8,9 @@ using Microsoft.AspNetCore.Localization;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Read environment before configuring EF
+var env = builder.Environment;
+
 // ✅ Чтение строки подключения из переменной окружения
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 
@@ -24,9 +27,13 @@ builder.Services.AddDbContext<ApplicationDbContext>(opt =>
         else
             opt.UseSqlite(connectionString);
     }
-    else
+    else if (env.IsDevelopment())
     {
         opt.UseInMemoryDatabase("CloudCity");
+    }
+    else
+    {
+        throw new InvalidOperationException("Connection string is empty.");
     }
 });
 


### PR DESCRIPTION
## Summary
- Read environment before Entity Framework setup and use it to configure the context
- Throw an `InvalidOperationException` when no connection string is supplied in non-development environments
- Only fall back to the in-memory database during development while preserving SQL Server vs. SQLite selection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68baadff8b14832b90c02cea7909bb6e