### PR TITLE
Handle IsAvailable column during server/product migration

### DIFF
--- a/CloudCityCenter/Migrations/20250820125325_RenameServersToProductsAndAddProductFields.cs
+++ b/CloudCityCenter/Migrations/20250820125325_RenameServersToProductsAndAddProductFields.cs
@@ -15,12 +15,10 @@ IF OBJECT_ID(N'dbo.Servers', N'U') IS NOT NULL AND OBJECT_ID(N'dbo.Products', N'
     EXEC sp_rename N'dbo.Servers', N'Products';
 ");
 
-            migrationBuilder.AddColumn<bool>(
-                name: "IsAvailable",
-                table: "Products",
-                type: "bit",
-                nullable: false,
-                defaultValue: false);
+            migrationBuilder.Sql(@"
+IF COL_LENGTH('dbo.Products','IsAvailable') IS NULL
+    ALTER TABLE [dbo].[Products] ADD [IsAvailable] bit NOT NULL DEFAULT(0);
+");
 
             migrationBuilder.AddColumn<int>(
                 name: "Type",
@@ -88,9 +86,10 @@ IF OBJECT_ID(N'dbo.Servers', N'U') IS NOT NULL AND OBJECT_ID(N'dbo.Products', N'
                 name: "IX_Products_Slug",
                 table: "Products");
 
-            migrationBuilder.DropColumn(
-                name: "IsAvailable",
-                table: "Products");
+            migrationBuilder.Sql(@"
+IF COL_LENGTH('dbo.Products','IsAvailable') IS NOT NULL
+    ALTER TABLE [dbo].[Products] DROP COLUMN [IsAvailable];
+");
 
             migrationBuilder.DropColumn(
                 name: "Type",


### PR DESCRIPTION
## Summary
- Add conditional SQL to ensure Products.IsAvailable column is created only if missing when renaming Servers table
- Drop IsAvailable column only if present when rolling back

## Testing
- `dotnet build CloudCityCenter.sln`
- `dotnet ef migrations script --no-build --project CloudCityCenter/CloudCityCenter.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68baaec580b4832ba8fcb2aa68555b0a