### PR TITLE
Refactor migration to use EF Core APIs

### DIFF
--- a/CloudCityCenter/Migrations/20250820125325_RenameServersToProductsAndAddProductFields.cs
+++ b/CloudCityCenter/Migrations/20250820125325_RenameServersToProductsAndAddProductFields.cs
@@ -10,53 +10,65 @@ namespace CloudCityCenter.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            if (migrationBuilder.ActiveProvider != "Microsoft.EntityFrameworkCore.Sqlite")
-            {
-                migrationBuilder.Sql(@"
-IF OBJECT_ID(N'dbo.Servers', N'U') IS NOT NULL AND OBJECT_ID(N'dbo.Products', N'U') IS NULL
-    EXEC sp_rename N'dbo.Servers', N'Products';
-");
+            migrationBuilder.RenameTable(
+                name: "Servers",
+                newName: "Products");
 
-                migrationBuilder.Sql(@"
-IF COL_LENGTH('dbo.Products','IsAvailable') IS NULL
-    ALTER TABLE [dbo].[Products] ADD [IsAvailable] bit NOT NULL DEFAULT(0);
-");
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAvailable",
+                table: "Products",
+                nullable: false,
+                defaultValue: false);
 
-                migrationBuilder.Sql(@"
-IF COL_LENGTH('dbo.Products','Type') IS NULL
-    ALTER TABLE [dbo].[Products] ADD [Type] int NOT NULL DEFAULT(0);
-");
+            migrationBuilder.AddColumn<int>(
+                name: "Type",
+                table: "Products",
+                nullable: false,
+                defaultValue: 0);
 
-                migrationBuilder.Sql(@"
-IF COL_LENGTH('dbo.Products','Configuration') IS NULL
-    ALTER TABLE [dbo].[Products] ADD [Configuration] nvarchar(200) NOT NULL DEFAULT('');
-");
+            migrationBuilder.AddColumn<string>(
+                name: "Configuration",
+                table: "Products",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "");
 
-                migrationBuilder.Sql(@"
-IF COL_LENGTH('dbo.Products','ImageUrl') IS NULL
-    ALTER TABLE [dbo].[Products] ADD [ImageUrl] nvarchar(300) NULL DEFAULT(NULL);
-");
+            migrationBuilder.AddColumn<string>(
+                name: "ImageUrl",
+                table: "Products",
+                type: "nvarchar(300)",
+                maxLength: 300,
+                nullable: true);
 
-                migrationBuilder.Sql(@"
-IF COL_LENGTH('dbo.Products','IsPublished') IS NULL
-    ALTER TABLE [dbo].[Products] ADD [IsPublished] bit NOT NULL DEFAULT(0);
-");
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPublished",
+                table: "Products",
+                nullable: false,
+                defaultValue: false);
 
-                migrationBuilder.Sql(@"
-IF COL_LENGTH('dbo.Products','Location') IS NULL
-    ALTER TABLE [dbo].[Products] ADD [Location] nvarchar(100) NOT NULL DEFAULT('');
-");
+            migrationBuilder.AddColumn<string>(
+                name: "Location",
+                table: "Products",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
 
-                migrationBuilder.Sql(@"
-IF COL_LENGTH('dbo.Products','PricePerMonth') IS NULL
-    ALTER TABLE [dbo].[Products] ADD [PricePerMonth] decimal(18,2) NOT NULL DEFAULT(0);
-");
+            migrationBuilder.AddColumn<decimal>(
+                name: "PricePerMonth",
+                table: "Products",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
 
-                migrationBuilder.Sql(@"
-IF COL_LENGTH('dbo.Products','Slug') IS NULL
-    ALTER TABLE [dbo].[Products] ADD [Slug] nvarchar(100) NOT NULL DEFAULT('');
-");
-            }
+            migrationBuilder.AddColumn<string>(
+                name: "Slug",
+                table: "Products",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Products_Slug",
@@ -72,101 +84,41 @@ IF COL_LENGTH('dbo.Products','Slug') IS NULL
                 name: "IX_Products_Slug",
                 table: "Products");
 
-            if (migrationBuilder.ActiveProvider != "Microsoft.EntityFrameworkCore.Sqlite")
-            {
-                migrationBuilder.Sql(@"
-DECLARE @dcName NVARCHAR(128);
-SELECT @dcName = d.name
-FROM sys.default_constraints d
-JOIN sys.columns c ON c.default_object_id = d.object_id
-WHERE c.object_id = OBJECT_ID('dbo.Products') AND c.name = 'IsAvailable';
-IF @dcName IS NOT NULL EXEC('ALTER TABLE dbo.Products DROP CONSTRAINT ' + @dcName);
-IF COL_LENGTH('dbo.Products','IsAvailable') IS NOT NULL
-    ALTER TABLE dbo.Products DROP COLUMN [IsAvailable];
-");
+            migrationBuilder.DropColumn(
+                name: "IsAvailable",
+                table: "Products");
 
-                migrationBuilder.Sql(@"
-DECLARE @dcName NVARCHAR(128);
-SELECT @dcName = d.name
-FROM sys.default_constraints d
-JOIN sys.columns c ON c.default_object_id = d.object_id
-WHERE c.object_id = OBJECT_ID('dbo.Products') AND c.name = 'Type';
-IF @dcName IS NOT NULL EXEC('ALTER TABLE dbo.Products DROP CONSTRAINT ' + @dcName);
-IF COL_LENGTH('dbo.Products','Type') IS NOT NULL
-    ALTER TABLE dbo.Products DROP COLUMN [Type];
-");
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Products");
 
-                migrationBuilder.Sql(@"
-DECLARE @dcName NVARCHAR(128);
-SELECT @dcName = d.name
-FROM sys.default_constraints d
-JOIN sys.columns c ON c.default_object_id = d.object_id
-WHERE c.object_id = OBJECT_ID('dbo.Products') AND c.name = 'Configuration';
-IF @dcName IS NOT NULL EXEC('ALTER TABLE dbo.Products DROP CONSTRAINT ' + @dcName);
-IF COL_LENGTH('dbo.Products','Configuration') IS NOT NULL
-    ALTER TABLE dbo.Products DROP COLUMN [Configuration];
-");
+            migrationBuilder.DropColumn(
+                name: "Configuration",
+                table: "Products");
 
-                migrationBuilder.Sql(@"
-DECLARE @dcName NVARCHAR(128);
-SELECT @dcName = d.name
-FROM sys.default_constraints d
-JOIN sys.columns c ON c.default_object_id = d.object_id
-WHERE c.object_id = OBJECT_ID('dbo.Products') AND c.name = 'ImageUrl';
-IF @dcName IS NOT NULL EXEC('ALTER TABLE dbo.Products DROP CONSTRAINT ' + @dcName);
-IF COL_LENGTH('dbo.Products','ImageUrl') IS NOT NULL
-    ALTER TABLE dbo.Products DROP COLUMN [ImageUrl];
-");
+            migrationBuilder.DropColumn(
+                name: "ImageUrl",
+                table: "Products");
 
-                migrationBuilder.Sql(@"
-DECLARE @dcName NVARCHAR(128);
-SELECT @dcName = d.name
-FROM sys.default_constraints d
-JOIN sys.columns c ON c.default_object_id = d.object_id
-WHERE c.object_id = OBJECT_ID('dbo.Products') AND c.name = 'IsPublished';
-IF @dcName IS NOT NULL EXEC('ALTER TABLE dbo.Products DROP CONSTRAINT ' + @dcName);
-IF COL_LENGTH('dbo.Products','IsPublished') IS NOT NULL
-    ALTER TABLE dbo.Products DROP COLUMN [IsPublished];
-");
+            migrationBuilder.DropColumn(
+                name: "IsPublished",
+                table: "Products");
 
-                migrationBuilder.Sql(@"
-DECLARE @dcName NVARCHAR(128);
-SELECT @dcName = d.name
-FROM sys.default_constraints d
-JOIN sys.columns c ON c.default_object_id = d.object_id
-WHERE c.object_id = OBJECT_ID('dbo.Products') AND c.name = 'Location';
-IF @dcName IS NOT NULL EXEC('ALTER TABLE dbo.Products DROP CONSTRAINT ' + @dcName);
-IF COL_LENGTH('dbo.Products','Location') IS NOT NULL
-    ALTER TABLE dbo.Products DROP COLUMN [Location];
-");
+            migrationBuilder.DropColumn(
+                name: "Location",
+                table: "Products");
 
-                migrationBuilder.Sql(@"
-DECLARE @dcName NVARCHAR(128);
-SELECT @dcName = d.name
-FROM sys.default_constraints d
-JOIN sys.columns c ON c.default_object_id = d.object_id
-WHERE c.object_id = OBJECT_ID('dbo.Products') AND c.name = 'PricePerMonth';
-IF @dcName IS NOT NULL EXEC('ALTER TABLE dbo.Products DROP CONSTRAINT ' + @dcName);
-IF COL_LENGTH('dbo.Products','PricePerMonth') IS NOT NULL
-    ALTER TABLE dbo.Products DROP COLUMN [PricePerMonth];
-");
+            migrationBuilder.DropColumn(
+                name: "PricePerMonth",
+                table: "Products");
 
-                migrationBuilder.Sql(@"
-DECLARE @dcName NVARCHAR(128);
-SELECT @dcName = d.name
-FROM sys.default_constraints d
-JOIN sys.columns c ON c.default_object_id = d.object_id
-WHERE c.object_id = OBJECT_ID('dbo.Products') AND c.name = 'Slug';
-IF @dcName IS NOT NULL EXEC('ALTER TABLE dbo.Products DROP CONSTRAINT ' + @dcName);
-IF COL_LENGTH('dbo.Products','Slug') IS NOT NULL
-    ALTER TABLE dbo.Products DROP COLUMN [Slug];
-");
+            migrationBuilder.DropColumn(
+                name: "Slug",
+                table: "Products");
 
-                migrationBuilder.Sql(@"
-IF OBJECT_ID(N'dbo.Products', N'U') IS NOT NULL AND OBJECT_ID(N'dbo.Servers', N'U') IS NULL
-    EXEC sp_rename N'dbo.Products', N'Servers';
-");
-            }
+            migrationBuilder.RenameTable(
+                name: "Products",
+                newName: "Servers");
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace raw SQL in RenameServersToProductsAndAddProductFields migration with EF Core RenameTable/AddColumn/CreateIndex APIs

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bac21e0d64832b9913b8c4697a4359