### PR TITLE
Use provider-specific CreatedUtc defaults

### DIFF
--- a/CloudCityCenter/Data/ApplicationDbContext.cs
+++ b/CloudCityCenter/Data/ApplicationDbContext.cs
@@ -80,8 +80,17 @@ public class ApplicationDbContext : IdentityDbContext
             .Property(s => s.Stock)
             .HasDefaultValue(9999);
 
-        builder.Entity<Server>()
-            .Property(s => s.CreatedUtc)
-            .HasDefaultValueSql("GETUTCDATE()");
+        if (Database.IsSqlServer())
+        {
+            builder.Entity<Server>()
+                .Property(s => s.CreatedUtc)
+                .HasDefaultValueSql("GETUTCDATE()");
+        }
+        else
+        {
+            builder.Entity<Server>()
+                .Property(s => s.CreatedUtc)
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Set Server.CreatedUtc default timestamp based on database provider
  - GETUTCDATE() for SQL Server
  - CURRENT_TIMESTAMP otherwise

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bac39dd38c832b8330520ef087180e