### PR TITLE
Remove redundant product index migration

### DIFF
--- a/CloudCityCenter/Migrations/20250820125325_RenameServersToProductsAndAddProductFields.cs
+++ b/CloudCityCenter/Migrations/20250820125325_RenameServersToProductsAndAddProductFields.cs
@@ -69,21 +69,11 @@ namespace CloudCityCenter.Migrations
                 maxLength: 100,
                 nullable: false,
                 defaultValue: "");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Products_Slug",
-                table: "Products",
-                column: "Slug",
-                unique: true);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_Products_Slug",
-                table: "Products");
-
             migrationBuilder.DropColumn(
                 name: "IsAvailable",
                 table: "Products");


### PR DESCRIPTION
## Summary
- Avoid recreating the `IX_Products_Slug` index during table rename migration

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bac44f75b0832b96cdc06215dc6dce