### PR TITLE
Add IP rate limiting for contact/about forms

### DIFF
--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Globalization;
 using CloudCityCenter.Data;
+using CloudCityCenter.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Localization;
@@ -40,6 +41,7 @@ else
 // Add services to the container.
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddControllersWithViews().AddViewLocalization();
+builder.Services.AddMemoryCache();
 
 builder.Services.AddDbContext<ApplicationDbContext>(opt =>
 {
@@ -72,6 +74,7 @@ builder.Services.AddSession(options =>
 
 // Register Email Service
 builder.Services.AddScoped<CloudCityCenter.Services.EmailService>();
+builder.Services.AddSingleton<FormRateLimitService>();
 
 var app = builder.Build();
 

--- a/CloudCityCenter/Services/FormRateLimitService.cs
+++ b/CloudCityCenter/Services/FormRateLimitService.cs
@@ -1,0 +1,138 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace CloudCityCenter.Services;
+
+public class FormRateLimitService
+{
+    private const int MaxSubmissions = 3;
+    private static readonly TimeSpan BlockDuration = TimeSpan.FromHours(24);
+    private static readonly TimeSpan CountDuration = TimeSpan.FromHours(24);
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> Locks = new();
+
+    private readonly IMemoryCache _memoryCache;
+    private readonly IDistributedCache _distributedCache;
+    private readonly ILogger<FormRateLimitService> _logger;
+
+    public FormRateLimitService(IMemoryCache memoryCache, IDistributedCache distributedCache, ILogger<FormRateLimitService> logger)
+    {
+        _memoryCache = memoryCache;
+        _distributedCache = distributedCache;
+        _logger = logger;
+    }
+
+    public async Task<bool> IsBlockedAsync(string ipAddress)
+    {
+        if (string.IsNullOrWhiteSpace(ipAddress))
+        {
+            return false;
+        }
+
+        var blockKey = GetBlockKey(ipAddress);
+        if (_memoryCache.TryGetValue(blockKey, out _))
+        {
+            return true;
+        }
+
+        var cachedValue = await _distributedCache.GetStringAsync(blockKey);
+        if (!string.IsNullOrEmpty(cachedValue))
+        {
+            _memoryCache.Set(blockKey, true, BlockDuration);
+            return true;
+        }
+
+        return false;
+    }
+
+    public async Task<bool> RegisterSubmissionAsync(string ipAddress)
+    {
+        if (string.IsNullOrWhiteSpace(ipAddress))
+        {
+            return false;
+        }
+
+        var gate = Locks.GetOrAdd(ipAddress, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync();
+        try
+        {
+            if (await IsBlockedAsync(ipAddress))
+            {
+                return true;
+            }
+
+            var currentCount = await GetSubmissionCountAsync(ipAddress);
+            currentCount++;
+
+            if (currentCount >= MaxSubmissions)
+            {
+                await SetBlockedAsync(ipAddress);
+                await ClearSubmissionCountAsync(ipAddress);
+                _logger.LogWarning("IP {IpAddress} blocked after reaching {MaxSubmissions} form submissions.", ipAddress, MaxSubmissions);
+                return true;
+            }
+
+            await SetSubmissionCountAsync(ipAddress, currentCount);
+            return false;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task<int> GetSubmissionCountAsync(string ipAddress)
+    {
+        var countKey = GetCountKey(ipAddress);
+        if (_memoryCache.TryGetValue(countKey, out int cachedCount))
+        {
+            return cachedCount;
+        }
+
+        var distributedValue = await _distributedCache.GetStringAsync(countKey);
+        if (int.TryParse(distributedValue, out var parsedCount))
+        {
+            _memoryCache.Set(countKey, parsedCount, CountDuration);
+            return parsedCount;
+        }
+
+        return 0;
+    }
+
+    private Task SetSubmissionCountAsync(string ipAddress, int count)
+    {
+        var countKey = GetCountKey(ipAddress);
+        _memoryCache.Set(countKey, count, CountDuration);
+        return _distributedCache.SetStringAsync(countKey, count.ToString(), new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = CountDuration
+        });
+    }
+
+    private Task ClearSubmissionCountAsync(string ipAddress)
+    {
+        var countKey = GetCountKey(ipAddress);
+        _memoryCache.Remove(countKey);
+        return _distributedCache.RemoveAsync(countKey);
+    }
+
+    private Task SetBlockedAsync(string ipAddress)
+    {
+        var blockKey = GetBlockKey(ipAddress);
+        _memoryCache.Set(blockKey, true, BlockDuration);
+        return _distributedCache.SetStringAsync(blockKey, "1", new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = BlockDuration
+        });
+    }
+
+    private static string GetBlockKey(string ipAddress)
+    {
+        return $"form-rate-limit:block:{ipAddress}";
+    }
+
+    private static string GetCountKey(string ipAddress)
+    {
+        return $"form-rate-limit:count:{ipAddress}";
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent abuse of Contact and About forms by blocking repeated submissions from the same IP after a small number of attempts. 
- Use a fast in-memory cache for single-server deployments and an optional distributed cache (via `IDistributedCache`, e.g. Redis) for multi-server deployments.

### Description

- Add `FormRateLimitService` that tracks submission counts per IP using `IMemoryCache` and `IDistributedCache`, increments counts, and blocks an IP for 24 hours after 3 submissions, using per-IP `SemaphoreSlim` to guard concurrency. 
- Enforce the rate limit in `ContactController.Submit` and `AboutController.Submit` by registering submissions and returning HTTP 403 when an IP is blocked. 
- Register `MemoryCache` and `FormRateLimitService` in `Program.cs` (`builder.Services.AddMemoryCache();` and `builder.Services.AddSingleton<FormRateLimitService>();`).
- Small controller updates: add `Microsoft.AspNetCore.Http` using, change `Submit` actions to `async Task<IActionResult>` and inject the new service into controllers.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697781ee8618832ba00a8c0a68fedf5a)