### PR TITLE
Add IP address tracking to admin messages list

### DIFF
--- a/CloudCityCenter/Areas/Admin/Views/Messages/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Messages/Index.cshtml
@@ -81,6 +81,7 @@
                                         <th>ID</th>
                                         <th>Имя</th>
                                         <th>Email</th>
+                                        <th>IP Address</th>
                                         <th>Телефон</th>
                                         <th>Страница</th>
                                         <th>Тема</th>
@@ -98,6 +99,7 @@
                                             <td>
                                                 <a href="mailto:@message.Email">@message.Email</a>
                                             </td>
+                                            <td>@(message.IpAddress ?? "-")</td>
                                             <td>@(message.Phone ?? "-")</td>
                                             <td>
                                                 <span class="badge bg-@(message.SourcePage == "About" ? "info" : "primary")">
@@ -141,4 +143,3 @@
         </div>
     </div>
 </div>
-

--- a/CloudCityCenter/Controllers/AboutController.cs
+++ b/CloudCityCenter/Controllers/AboutController.cs
@@ -73,7 +73,8 @@ public class AboutController : Controller
                             subject: Subject,
                             serviceType: null,
                             message: Message,
-                            sourcePage: "About"
+                            sourcePage: "About",
+                            ipAddress: ipAddress
                         );
 
                         if (success)

--- a/CloudCityCenter/Controllers/ContactController.cs
+++ b/CloudCityCenter/Controllers/ContactController.cs
@@ -75,7 +75,8 @@ namespace CloudCityCenter.Controllers
                             subject: null,
                             serviceType: ServiceType,
                             message: Message,
-                            sourcePage: "Contact"
+                            sourcePage: "Contact",
+                            ipAddress: ipAddress
                         );
 
                         if (success)

--- a/CloudCityCenter/Models/ContactMessage.cs
+++ b/CloudCityCenter/Models/ContactMessage.cs
@@ -26,6 +26,9 @@ public class ContactMessage
     [StringLength(100)]
     public string? ServiceType { get; set; }
 
+    [StringLength(45)]
+    public string? IpAddress { get; set; }
+
     [Required]
     public string Message { get; set; } = string.Empty;
 
@@ -39,4 +42,3 @@ public class ContactMessage
 
     public DateTime? ReadAt { get; set; }
 }
-

--- a/CloudCityCenter/Services/EmailService.cs
+++ b/CloudCityCenter/Services/EmailService.cs
@@ -231,7 +231,7 @@ public class EmailService
         }
     }
 
-    public async Task<bool> SendContactFormEmailAsync(string name, string email, string? phone, string? subject, string? serviceType, string message, string sourcePage)
+    public async Task<bool> SendContactFormEmailAsync(string name, string email, string? phone, string? subject, string? serviceType, string message, string sourcePage, string? ipAddress)
     {
         // Сохраняем письмо в базу данных
         var contactMessage = new ContactMessage
@@ -241,6 +241,7 @@ public class EmailService
             Phone = phone,
             Subject = subject,
             ServiceType = serviceType,
+            IpAddress = ipAddress,
             Message = message,
             SourcePage = sourcePage,
             CreatedAt = DateTime.UtcNow,
@@ -323,4 +324,3 @@ public class EmailService
         return await SendEmailAsync("support@cloudcity.center", emailSubject, emailBody, name, email);
     }
 }
-


### PR DESCRIPTION
### Motivation
- Record and surface the client IP for contact/about form submissions to aid auditing and troubleshooting. 
- Show the captured IP in the Admin → Messages list so admins can quickly see submission origin. 
- Propagate the remote IP from the HTTP request into the persisted message record.

### Description
- Added `IpAddress` (string, max length 45) to `ContactMessage` in `CloudCityCenter/Models/ContactMessage.cs` to store sender IP. 
- Extended `EmailService.SendContactFormEmailAsync` signature to accept `ipAddress` and populate the new `IpAddress` field when saving the `ContactMessage` (file `CloudCityCenter/Services/EmailService.cs`). 
- Passed the computed `ipAddress` from both `ContactController` and `AboutController` into `SendContactFormEmailAsync` (files `CloudCityCenter/Controllers/ContactController.cs` and `CloudCityCenter/Controllers/AboutController.cs`). 
- Added an "IP Address" column to the Admin messages view and display `message.IpAddress` in `CloudCityCenter/Areas/Admin/Views/Messages/Index.cshtml`.

### Testing
- No automated test suite was executed in this environment. 
- Attempted to run the application with `dotnet run --project CloudCityCenter`, but the command failed because the `dotnet` SDK is not available (`dotnet: command not found`). 
- Code changes were applied and committed locally; note that a database migration will be required to add the new `IpAddress` column to existing databases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697788816484832b8d041f71045a6907)