### PR TITLE
Capture and surface external IPs for form submissions

### DIFF
--- a/CloudCityCenter/Areas/Admin/Views/Messages/Details.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Messages/Details.cshtml
@@ -95,6 +95,12 @@
                                     <a href="mailto:@Model.Email">@Model.Email</a>
                                 </dd>
 
+                                @if (!string.IsNullOrEmpty(Model.IpAddress))
+                                {
+                                    <dt class="col-sm-4">IP адрес:</dt>
+                                    <dd class="col-sm-8">@Model.IpAddress</dd>
+                                }
+
                                 @if (!string.IsNullOrEmpty(Model.Phone))
                                 {
                                     <dt class="col-sm-4">Телефон:</dt>
@@ -139,4 +145,3 @@
         </div>
     </div>
 </div>
-

--- a/CloudCityCenter/Controllers/AboutController.cs
+++ b/CloudCityCenter/Controllers/AboutController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using CloudCityCenter.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using System.Linq;
 
 namespace CloudCityCenter.Controllers;
 
@@ -26,6 +27,21 @@ public class AboutController : Controller
         return _localizerFactory.Create("Views.About.Index", "CloudCityCenter");
     }
 
+    private string GetClientIpAddress()
+    {
+        var forwardedFor = HttpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+        if (!string.IsNullOrWhiteSpace(forwardedFor))
+        {
+            var firstForwarded = forwardedFor.Split(',').Select(entry => entry.Trim()).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(firstForwarded))
+            {
+                return firstForwarded;
+            }
+        }
+
+        return HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+    }
+
     public IActionResult Index()
     {
         // SEO оптимизация с локализацией
@@ -41,7 +57,7 @@ public class AboutController : Controller
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Submit(string Name, string Email, string Subject, string Message)
         {
-            var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+            var ipAddress = GetClientIpAddress();
             if (await _formRateLimitService.RegisterSubmissionAsync(ipAddress))
             {
                 _logger.LogWarning("Blocked about form submission from IP {IpAddress}", ipAddress);

--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -42,6 +42,12 @@ else
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddControllersWithViews().AddViewLocalization();
 builder.Services.AddMemoryCache();
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
 
 builder.Services.AddDbContext<ApplicationDbContext>(opt =>
 {

--- a/CloudCityCenter/Services/EmailService.cs
+++ b/CloudCityCenter/Services/EmailService.cs
@@ -310,6 +310,11 @@ public class EmailService
                 <div class=""label"">Тип услуги:</div>
                 <div class=""value"">{serviceType}</div>
             </div>")}
+            {(string.IsNullOrEmpty(ipAddress) ? "" : $@"
+            <div class=""field"">
+                <div class=""label"">IP адрес:</div>
+                <div class=""value"">{ipAddress}</div>
+            </div>")}
             <div class=""field"">
                 <div class=""label"">Сообщение:</div>
                 <div class=""value"">{message.Replace("\n", "<br>")}</div>


### PR DESCRIPTION
### Motivation
- Forms submitted behind a reverse proxy were recording the proxy IP rather than the real client IP, which reduces usefulness of stored messages and rate-limiting accuracy.  
- Storing and surfacing the real external IP improves admin visibility and incident investigation.  
- Including the IP in notification emails helps support staff quickly triage submissions.

### Description
- Configure forwarded header handling by adding `ForwardedHeadersOptions` in `Program.cs` to accept `X-Forwarded-For` and `X-Forwarded-Proto` and clear known networks/proxies.  
- Add a `GetClientIpAddress()` helper to `ContactController` and `AboutController` to resolve the first value from `X-Forwarded-For` (falling back to `HttpContext.Connection.RemoteIpAddress`) and use it for form submissions.  
- Pass the resolved IP into the existing `SendContactFormEmailAsync` so the IP is saved on the `ContactMessage` and included in outgoing email body in `EmailService`.  
- Surface the stored IP in the admin UI by showing `IpAddress` in `Areas/Admin/Views/Messages/Details.cshtml` when present.

### Testing
- Attempted to run the app with `dotnet run --project /workspace/CloudCity/CloudCityCenter/CloudCityCenter.csproj`, but the `dotnet` command is not available in the environment so runtime/integration tests could not be executed.  
- No automated unit or integration tests were executed in this environment due to missing .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779727a298832bb17700b7d3d9fc85)