### PR TITLE
Add friendly 403 status page messaging

### DIFF
--- a/CloudCityCenter/Controllers/HomeController.cs
+++ b/CloudCityCenter/Controllers/HomeController.cs
@@ -4,6 +4,7 @@ using CloudCityCenter.Models;
 using System.Threading.Tasks;
 using CloudCityCenter.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Localization;
 
 namespace CloudCityCenter.Controllers;
@@ -49,6 +50,17 @@ public class HomeController : Controller
         ViewData["Description"] = "Политика конфиденциальности CloudCityCenter - аренда серверов по всему миру.";
         ViewData["Keywords"] = "политика конфиденциальности, конфиденциальность";
         
+        return View();
+    }
+
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public IActionResult StatusCode(int code)
+    {
+        ViewData["StatusCode"] = code;
+        ViewData["Title"] = code == StatusCodes.Status403Forbidden
+            ? "Form submission limit reached"
+            : "Something went wrong";
+
         return View();
     }
 

--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -318,6 +318,8 @@ else
     app.UseDeveloperExceptionPage();
 }
 
+app.UseStatusCodePagesWithReExecute("/Home/StatusCode", "?code={0}");
+
 // Completely disable HTTPS redirection when behind reverse proxy (nginx handles HTTPS)
 // This prevents ERR_TOO_MANY_REDIRECTS errors
 if (!useReverseProxy)

--- a/CloudCityCenter/Views/Home/StatusCode.cshtml
+++ b/CloudCityCenter/Views/Home/StatusCode.cshtml
@@ -1,0 +1,27 @@
+@using Microsoft.AspNetCore.Http
+@{
+    var statusCode = ViewData["StatusCode"] as int? ?? 0;
+    var isForbidden = statusCode == StatusCodes.Status403Forbidden;
+}
+
+<section class="py-5">
+    <div class="container text-center">
+        <h1 class="display-5 fw-bold mb-3">@ViewData["Title"]</h1>
+        @if (isForbidden)
+        {
+            <p class="lead mb-4">
+                You have reached the form submission limit. Access will be restored automatically after 24 hours.
+            </p>
+            <p class="text-muted">
+                If you need immediate assistance, please contact our support team.
+            </p>
+        }
+        else
+        {
+            <p class="lead mb-4">
+                We ran into an unexpected error. Please try again later.
+            </p>
+        }
+        <a class="btn btn-primary mt-3" href="@Url.Action("Index", "Home")">Return to Home</a>
+    </div>
+</section>


### PR DESCRIPTION
### Motivation

- Provide users a helpful message when a 403 is returned due to exceeding form submission limits so they understand access will be restored after 24 hours.

### Description

- Enable status code re-execution middleware with `app.UseStatusCodePagesWithReExecute("/Home/StatusCode", "?code={0}")` in `CloudCityCenter/Program.cs`.
- Add a `StatusCode` action in `CloudCityCenter/Controllers/HomeController.cs` that sets a friendly title for 403 responses and passes the status code to the view.
- Add a Razor view `CloudCityCenter/Views/Home/StatusCode.cshtml` that displays a user-friendly message for 403 errors and a generic message for other status codes.

### Testing

- Attempted to run the application with `dotnet run --project CloudCityCenter/CloudCityCenter.csproj --urls http://0.0.0.0:5000`, but `dotnet` is not available in the environment so the app could not be started (no automated runtime verification performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977997d0600832bb99f41599df131bf)