### PR TITLE
Mark HomeController.StatusCode as new to silence CS0114 warning

### DIFF
--- a/CloudCityCenter/Controllers/HomeController.cs
+++ b/CloudCityCenter/Controllers/HomeController.cs
@@ -54,7 +54,7 @@ public class HomeController : Controller
     }
 
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-    public IActionResult StatusCode(int code)
+    public new IActionResult StatusCode(int code)
     {
         ViewData["StatusCode"] = code;
         ViewData["Title"] = code == StatusCodes.Status403Forbidden


### PR DESCRIPTION
### Motivation
- The `StatusCode` action in `HomeController` was unintentionally hiding a base member, causing the compiler warning `CS0114`, so the change makes the hiding explicit.

### Description
- Added the `new` modifier to the `StatusCode(int code)` method in `CloudCityCenter/Controllers/HomeController.cs` to indicate intentional hiding of the base method.

### Testing
- No automated tests were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779bcd9a28832b8112e3b829ae5e56)