### PR TITLE
Add one-time --reset-admin startup command

### DIFF
--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -104,6 +104,93 @@ TaskScheduler.UnobservedTaskException += (sender, e) =>
     e.SetObserved();
 };
 
+
+if (args.Any(a => a.StartsWith("--reset-admin=")))
+{
+    var resetArg = args.FirstOrDefault(a => a.StartsWith("--reset-admin="));
+    var resetEmail = resetArg?.Split('=', 2)[1];
+
+    if (string.IsNullOrWhiteSpace(resetEmail))
+    {
+        Console.WriteLine("❌ Invalid --reset-admin argument. Example: --reset-admin=support@cloudcity.center");
+        return;
+    }
+
+    using var scope = app.Services.CreateScope();
+    var serviceProvider = scope.ServiceProvider;
+    var userManager = serviceProvider.GetRequiredService<UserManager<IdentityUser>>();
+    var roleManager = serviceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+    var user = await userManager.FindByEmailAsync(resetEmail);
+    if (user == null)
+    {
+        Console.WriteLine($"❌ User not found: {resetEmail}");
+        return;
+    }
+
+    user.LockoutEnd = null;
+    user.LockoutEnabled = false;
+    user.EmailConfirmed = true;
+
+    var userUpdateResult = await userManager.UpdateAsync(user);
+    if (!userUpdateResult.Succeeded)
+    {
+        Console.WriteLine($"❌ Failed to update user: {resetEmail}");
+        foreach (var error in userUpdateResult.Errors)
+        {
+            Console.WriteLine($"  - {error.Code}: {error.Description}");
+        }
+        return;
+    }
+
+    const string temporaryPassword = "Admin12345!";
+    var resetToken = await userManager.GeneratePasswordResetTokenAsync(user);
+    var resetPasswordResult = await userManager.ResetPasswordAsync(user, resetToken, temporaryPassword);
+    if (!resetPasswordResult.Succeeded)
+    {
+        Console.WriteLine($"❌ Failed to reset password: {resetEmail}");
+        foreach (var error in resetPasswordResult.Errors)
+        {
+            Console.WriteLine($"  - {error.Code}: {error.Description}");
+        }
+        return;
+    }
+
+    const string adminRole = "Admin";
+    if (!await roleManager.RoleExistsAsync(adminRole))
+    {
+        var createRoleResult = await roleManager.CreateAsync(new IdentityRole(adminRole));
+        if (!createRoleResult.Succeeded)
+        {
+            Console.WriteLine($"❌ Failed to create role: {adminRole}");
+            foreach (var error in createRoleResult.Errors)
+            {
+                Console.WriteLine($"  - {error.Code}: {error.Description}");
+            }
+            return;
+        }
+    }
+
+    if (!await userManager.IsInRoleAsync(user, adminRole))
+    {
+        var addToRoleResult = await userManager.AddToRoleAsync(user, adminRole);
+        if (!addToRoleResult.Succeeded)
+        {
+            Console.WriteLine($"❌ Failed to add user to role '{adminRole}': {resetEmail}");
+            foreach (var error in addToRoleResult.Errors)
+            {
+                Console.WriteLine($"  - {error.Code}: {error.Description}");
+            }
+            return;
+        }
+    }
+
+    Console.WriteLine("✅ Admin password reset successful");
+    Console.WriteLine($"Email: {resetEmail}");
+    Console.WriteLine($"Temporary password: {temporaryPassword}");
+    return;
+}
+
 if (args.Any(a => a == "--seed" || a.StartsWith("--seed-admin=") || a == "--migrate-data"))
 {
     // Ensure connection string is provided via configuration/environment


### PR DESCRIPTION
### Motivation
- Provide a safe, one-time admin account recovery flow so an operator can reset the admin password without manual DB edits.  
- Reuse the existing startup-argument pattern already used for `--seed`, `--seed-admin=` and `--migrate-data`.  
- Ensure the target account has the `Admin` role and a known temporary password so access can be regained quickly.

### Description
- Added a new handler in `CloudCityCenter/Program.cs` that runs only when `--reset-admin=<email>` is present and returns immediately after finishing.  
- The handler creates a DI scope, resolves `UserManager<IdentityUser>` and `RoleManager<IdentityRole>`, finds the user by email, and prints `❌ User not found: <email>` and exits if missing.  
- It clears lockout (`LockoutEnd = null`, `LockoutEnabled = false`), sets `EmailConfirmed = true`, updates the user with `UpdateAsync`, generates a reset token and resets the password to the temporary password `Admin12345!`, and prints any Identity errors returned.  
- It ensures the `Admin` role exists and that the user is a member of that role, and prints a success block showing the email and temporary password on completion.

### Testing
- Attempted to build the solution with `dotnet build CloudCityCenter.sln` but the environment does not have the `dotnet` SDK installed, so no compile/run automated tests were executed.  
- Static / local edits were validated by updating `CloudCityCenter/Program.cs` and confirming the new `--reset-admin` block is placed before the existing seed/migrate logic so normal startup is unaffected.  
- Usage to run the one-time reset is `dotnet run -- --reset-admin=support@cloudcity.center` (or `dotnet CloudCityCenter.dll --reset-admin=support@cloudcity.center`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88653a9bc832b99a834a92face6dd)