### PR TITLE
Admin Messages: add bulk selection and bulk delete

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/MessagesController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/MessagesController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -174,10 +175,51 @@ public class MessagesController : Controller
         {
             _context.ContactMessages.Remove(message);
             await _context.SaveChangesAsync();
-            _logger.LogInformation($"Message {id} deleted");
+            _logger.LogInformation("Message {MessageId} deleted", id);
         }
 
         return RedirectToAction(nameof(Index));
+    }
+
+    // POST: Admin/Messages/BulkDelete
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> BulkDelete(List<int>? selectedMessageIds, string? sourcePage = null, bool? unreadOnly = null)
+    {
+        if (selectedMessageIds == null || selectedMessageIds.Count == 0)
+        {
+            TempData["Error"] = "Please select at least one message.";
+            return RedirectToAction(nameof(Index), new { sourcePage, unreadOnly });
+        }
+
+        var normalizedIds = selectedMessageIds
+            .Where(id => id > 0)
+            .Distinct()
+            .ToList();
+
+        if (normalizedIds.Count == 0)
+        {
+            TempData["Error"] = "Please select at least one message.";
+            return RedirectToAction(nameof(Index), new { sourcePage, unreadOnly });
+        }
+
+        var messagesToDelete = await _context.ContactMessages
+            .Where(m => normalizedIds.Contains(m.Id))
+            .ToListAsync();
+
+        if (messagesToDelete.Count == 0)
+        {
+            TempData["Error"] = "No selected messages were found.";
+            return RedirectToAction(nameof(Index), new { sourcePage, unreadOnly });
+        }
+
+        _context.ContactMessages.RemoveRange(messagesToDelete);
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation("Bulk deleted {DeletedCount} messages", messagesToDelete.Count);
+        TempData["Success"] = "Selected messages deleted successfully";
+
+        return RedirectToAction(nameof(Index), new { sourcePage, unreadOnly });
     }
 }
 

--- a/CloudCityCenter/Areas/Admin/Views/Messages/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Messages/Index.cshtml
@@ -25,6 +25,20 @@
                 </div>
             }
 
+            @if (TempData["Success"] != null)
+            {
+                <div class="alert alert-success" role="alert">
+                    <i class="bi bi-check-circle me-2"></i>@TempData["Success"]
+                </div>
+            }
+
+            @if (TempData["Error"] != null)
+            {
+                <div class="alert alert-danger" role="alert">
+                    <i class="bi bi-exclamation-triangle me-2"></i>@TempData["Error"]
+                </div>
+            }
+
             <!-- Навигация по админ-панели -->
             <div class="mb-3">
                 <a asp-area="Admin" asp-controller="Products" asp-action="Index" class="btn btn-primary">
@@ -74,63 +88,87 @@
                 <div class="card-body">
                     @if (Model.Any())
                     {
-                        <div class="table-responsive">
-                            <table class="table table-hover">
-                                <thead>
-                                    <tr>
-                                        <th>ID</th>
-                                        <th>Имя</th>
-                                        <th>Email</th>
-                                        <th>IP Address</th>
-                                        <th>Телефон</th>
-                                        <th>Страница</th>
-                                        <th>Тема</th>
-                                        <th>Дата</th>
-                                        <th>Статус</th>
-                                        <th>Действия</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @foreach (var message in Model)
-                                    {
-                                        <tr class="@(!message.IsRead ? "table-warning" : "")">
-                                            <td>@message.Id</td>
-                                            <td><strong>@message.Name</strong></td>
-                                            <td>
-                                                <a href="mailto:@message.Email">@message.Email</a>
-                                            </td>
-                                            <td>@(message.IpAddress ?? "-")</td>
-                                            <td>@(message.Phone ?? "-")</td>
-                                            <td>
-                                                <span class="badge bg-@(message.SourcePage == "About" ? "info" : "primary")">
-                                                    @message.SourcePage
-                                                </span>
-                                            </td>
-                                            <td>@(message.Subject ?? "-")</td>
-                                            <td>@message.CreatedAt.ToString("dd.MM.yyyy HH:mm")</td>
-                                            <td>
-                                                @if (message.IsRead)
-                                                {
-                                                    <span class="badge bg-success">Прочитано</span>
-                                                }
-                                                else
-                                                {
-                                                    <span class="badge bg-warning">Новое</span>
-                                                }
-                                            </td>
-                                            <td>
-                                                <a asp-action="Details" asp-route-id="@message.Id" class="btn btn-sm btn-info">
-                                                    <i class="bi bi-eye me-1"></i>Просмотр
-                                                </a>
-                                                <a asp-action="Delete" asp-route-id="@message.Id" class="btn btn-sm btn-danger">
-                                                    <i class="bi bi-trash me-1"></i>Удалить
-                                                </a>
-                                            </td>
+                        <form asp-action="BulkDelete" method="post">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="sourcePage" value="@ViewBag.SourcePage" />
+                            <input type="hidden" name="unreadOnly" value="@ViewBag.UnreadOnly" />
+
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <div class="text-muted">Выберите письма для массового удаления</div>
+                                <button type="submit" class="btn btn-danger" onclick="return confirm('Delete selected messages?');">
+                                    <i class="bi bi-trash me-1"></i>Delete Selected
+                                </button>
+                            </div>
+
+                            <div class="table-responsive">
+                                <table class="table table-hover">
+                                    <thead>
+                                        <tr>
+                                            <th style="width: 40px;">
+                                                <input class="form-check-input" type="checkbox" id="selectAllMessages" aria-label="Select all messages" />
+                                            </th>
+                                            <th>ID</th>
+                                            <th>Имя</th>
+                                            <th>Email</th>
+                                            <th>IP Address</th>
+                                            <th>Телефон</th>
+                                            <th>Страница</th>
+                                            <th>Тема</th>
+                                            <th>Дата</th>
+                                            <th>Статус</th>
+                                            <th>Действия</th>
                                         </tr>
-                                    }
-                                </tbody>
-                            </table>
-                        </div>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var message in Model)
+                                        {
+                                            <tr class="@(!message.IsRead ? "table-warning" : "")">
+                                                <td>
+                                                    <input
+                                                        class="form-check-input js-message-checkbox"
+                                                        type="checkbox"
+                                                        name="selectedMessageIds"
+                                                        value="@message.Id"
+                                                        aria-label="Select message @message.Id" />
+                                                </td>
+                                                <td>@message.Id</td>
+                                                <td><strong>@message.Name</strong></td>
+                                                <td>
+                                                    <a href="mailto:@message.Email">@message.Email</a>
+                                                </td>
+                                                <td>@(message.IpAddress ?? "-")</td>
+                                                <td>@(message.Phone ?? "-")</td>
+                                                <td>
+                                                    <span class="badge bg-@(message.SourcePage == "About" ? "info" : "primary")">
+                                                        @message.SourcePage
+                                                    </span>
+                                                </td>
+                                                <td>@(message.Subject ?? "-")</td>
+                                                <td>@message.CreatedAt.ToString("dd.MM.yyyy HH:mm")</td>
+                                                <td>
+                                                    @if (message.IsRead)
+                                                    {
+                                                        <span class="badge bg-success">Прочитано</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="badge bg-warning">Новое</span>
+                                                    }
+                                                </td>
+                                                <td>
+                                                    <a asp-action="Details" asp-route-id="@message.Id" class="btn btn-sm btn-info">
+                                                        <i class="bi bi-eye me-1"></i>Просмотр
+                                                    </a>
+                                                    <a asp-action="Delete" asp-route-id="@message.Id" class="btn btn-sm btn-danger">
+                                                        <i class="bi bi-trash me-1"></i>Удалить
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        </form>
                     }
                     else
                     {
@@ -143,3 +181,35 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script>
+        (function () {
+            const selectAllCheckbox = document.getElementById('selectAllMessages');
+            const rowCheckboxes = document.querySelectorAll('.js-message-checkbox');
+
+            if (!selectAllCheckbox || rowCheckboxes.length === 0) {
+                return;
+            }
+
+            const syncSelectAll = () => {
+                const allChecked = Array.from(rowCheckboxes).every((checkbox) => checkbox.checked);
+                const anyChecked = Array.from(rowCheckboxes).some((checkbox) => checkbox.checked);
+
+                selectAllCheckbox.checked = allChecked;
+                selectAllCheckbox.indeterminate = anyChecked && !allChecked;
+            };
+
+            selectAllCheckbox.addEventListener('change', function () {
+                rowCheckboxes.forEach((checkbox) => {
+                    checkbox.checked = this.checked;
+                });
+                syncSelectAll();
+            });
+
+            rowCheckboxes.forEach((checkbox) => {
+                checkbox.addEventListener('change', syncSelectAll);
+            });
+        })();
+    </script>
+}


### PR DESCRIPTION
### Motivation
- Deleting messages one-by-one in the Admin Messages page is slow for moderation; admins need to select and remove many messages from the list view in a single action.

### Description
- Added a `BulkDelete` POST action to `CloudCityCenter/Areas/Admin/Controllers/MessagesController.cs` that accepts `List<int>? selectedMessageIds`, validates input, normalizes IDs (`>0`, distinct), loads existing records, deletes them with `RemoveRange`, logs the deletion, and sets `TempData["Success"]`/`TempData["Error"]` before redirecting back to `Index` while preserving `sourcePage`/`unreadOnly` filter parameters.
- Updated `CloudCityCenter/Areas/Admin/Views/Messages/Index.cshtml` to support bulk operations by adding a form that posts to `BulkDelete`, per-row checkboxes named `selectedMessageIds`, a header "Select All" checkbox, hidden fields to preserve filters, and rendering of `TempData` success/error messages.
- Implemented small client-side JavaScript in the index view to sync the header select-all checkbox with individual row checkboxes (including indeterminate state) and kept existing single-message details/delete flows unchanged.
- Security and robustness: the controller remains protected by `[Authorize(Roles = "Admin")]`, the bulk action has `[ValidateAntiForgeryToken]`, input is validated and nonexistent IDs are ignored safely.

### Testing
- Attempted an automated build with `dotnet build CloudCityCenter/CloudCityCenter.csproj`, but it could not be executed in this environment because `dotnet` is not installed (build not run here).
- Repository-level checks (`git` status / commit / show) were performed successfully to create and inspect the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e893bdcbcc832b87949f009ca3561e)