### PR TITLE
Add admin IP block list management and request-blocking middleware

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using CloudCityCenter.Models.Admin;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace CloudCityCenter.Areas.Admin.Controllers;
+
+[Area("Admin")]
+[Authorize(Roles = "Admin")]
+public class BlockedIpsController : Controller
+{
+    private readonly ApplicationDbContext _context;
+
+    public BlockedIpsController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var blockedIps = await _context.BlockedIpAddresses
+            .OrderByDescending(x => x.IsActive)
+            .ThenByDescending(x => x.CreatedAt)
+            .ToListAsync();
+
+        return View(blockedIps);
+    }
+
+    public IActionResult Create()
+    {
+        return View(new BlockedIpCreateViewModel());
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(BlockedIpCreateViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(model);
+        }
+
+        if (!TryNormalizeIp(model.IpAddress, out var normalizedIp))
+        {
+            ModelState.AddModelError(nameof(model.IpAddress), "Please enter a valid IPv4 or IPv6 address.");
+            return View(model);
+        }
+
+        var alreadyBlocked = await _context.BlockedIpAddresses
+            .AnyAsync(x => x.IsActive && x.NormalizedIpAddress == normalizedIp);
+
+        if (alreadyBlocked)
+        {
+            TempData["ErrorMessage"] = "IP address already exists";
+            ModelState.AddModelError(nameof(model.IpAddress), "This IP address is already blocked.");
+            return View(model);
+        }
+
+        var entity = new BlockedIpAddress
+        {
+            IpAddress = model.IpAddress.Trim(),
+            NormalizedIpAddress = normalizedIp,
+            Reason = string.IsNullOrWhiteSpace(model.Reason) ? null : model.Reason.Trim(),
+            CreatedBy = User?.Identity?.Name,
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true
+        };
+
+        _context.BlockedIpAddresses.Add(entity);
+        await _context.SaveChangesAsync();
+
+        TempData["SuccessMessage"] = "IP address blocked successfully";
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Unblock(int id)
+    {
+        var entry = await _context.BlockedIpAddresses.FindAsync(id);
+        if (entry == null)
+        {
+            TempData["ErrorMessage"] = "Blocked IP was not found";
+            return RedirectToAction(nameof(Index));
+        }
+
+        entry.IsActive = false;
+        await _context.SaveChangesAsync();
+
+        TempData["SuccessMessage"] = "IP address removed from block list";
+        return RedirectToAction(nameof(Index));
+    }
+
+    private static bool TryNormalizeIp(string? rawIp, out string normalizedIp)
+    {
+        normalizedIp = string.Empty;
+        if (string.IsNullOrWhiteSpace(rawIp))
+        {
+            return false;
+        }
+
+        return IPAddress.TryParse(rawIp.Trim(), out var parsedIp) &&
+               TryNormalizeIp(parsedIp, out normalizedIp);
+    }
+
+    private static bool TryNormalizeIp(IPAddress? ipAddress, out string normalizedIp)
+    {
+        normalizedIp = string.Empty;
+        if (ipAddress == null)
+        {
+            return false;
+        }
+
+        if (ipAddress.IsIPv4MappedToIPv6)
+        {
+            ipAddress = ipAddress.MapToIPv4();
+        }
+
+        normalizedIp = ipAddress.ToString();
+        return true;
+    }
+}

--- a/CloudCityCenter/Areas/Admin/Views/BlockedIps/Create.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/BlockedIps/Create.cshtml
@@ -1,0 +1,34 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@model CloudCityCenter.Models.Admin.BlockedIpCreateViewModel
+@{
+    ViewData["Title"] = "Block IP address";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<h1>Block IP address</h1>
+
+<form asp-area="Admin" asp-controller="BlockedIps" asp-action="Create" method="post" class="mt-4">
+    @Html.AntiForgeryToken()
+    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+    <div class="mb-3">
+        <label asp-for="IpAddress" class="form-label"></label>
+        <input asp-for="IpAddress" class="form-control" placeholder="e.g. 203.0.113.12 or 2001:db8::10" />
+        <span asp-validation-for="IpAddress" class="text-danger"></span>
+    </div>
+
+    <div class="mb-3">
+        <label asp-for="Reason" class="form-label"></label>
+        <textarea asp-for="Reason" class="form-control" rows="3" placeholder="Optional reason"></textarea>
+        <span asp-validation-for="Reason" class="text-danger"></span>
+    </div>
+
+    <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-danger">Block IP</button>
+        <a asp-area="Admin" asp-controller="BlockedIps" asp-action="Index" class="btn btn-secondary">Cancel</a>
+    </div>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
@@ -1,0 +1,70 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@model IEnumerable<CloudCityCenter.Models.BlockedIpAddress>
+@{
+    ViewData["Title"] = "Blocked IP addresses";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<h1>Blocked IP addresses</h1>
+
+<div class="mb-3 d-flex gap-2 flex-wrap">
+    <a asp-area="Admin" asp-controller="BlockedIps" asp-action="Create" class="btn btn-danger">
+        <i class="bi bi-shield-x me-2"></i>Block IP address
+    </a>
+    <a asp-area="Admin" asp-controller="Products" asp-action="Index" class="btn btn-secondary">
+        <i class="bi bi-arrow-left me-2"></i>Back to admin panel
+    </a>
+</div>
+
+@if (TempData["SuccessMessage"] != null)
+{
+    <div class="alert alert-success">@TempData["SuccessMessage"]</div>
+}
+
+@if (TempData["ErrorMessage"] != null)
+{
+    <div class="alert alert-danger">@TempData["ErrorMessage"]</div>
+}
+
+<table class="table table-striped align-middle">
+    <thead>
+        <tr>
+            <th>IP address</th>
+            <th>Reason</th>
+            <th>Created</th>
+            <th>Created by</th>
+            <th>Status</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var item in Model)
+    {
+        <tr>
+            <td><code>@item.IpAddress</code></td>
+            <td>@(string.IsNullOrWhiteSpace(item.Reason) ? "—" : item.Reason)</td>
+            <td>@item.CreatedAt.ToString("u")</td>
+            <td>@(string.IsNullOrWhiteSpace(item.CreatedBy) ? "—" : item.CreatedBy)</td>
+            <td>
+                @if (item.IsActive)
+                {
+                    <span class="badge bg-danger">Active</span>
+                }
+                else
+                {
+                    <span class="badge bg-secondary">Inactive</span>
+                }
+            </td>
+            <td>
+                @if (item.IsActive)
+                {
+                    <form asp-area="Admin" asp-controller="BlockedIps" asp-action="Unblock" asp-route-id="@item.Id" method="post" class="d-inline">
+                        @Html.AntiForgeryToken()
+                        <button type="submit" class="btn btn-sm btn-outline-success">Unblock</button>
+                    </form>
+                }
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/CloudCityCenter/Areas/Admin/Views/Products/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Products/Index.cshtml
@@ -20,6 +20,9 @@
     <a asp-area="Admin" asp-controller="Messages" asp-action="Index" class="btn btn-warning">
         <i class="bi bi-envelope-fill me-2"></i>Письма
     </a>
+    <a asp-area="Admin" asp-controller="BlockedIps" asp-action="Index" class="btn btn-danger">
+        <i class="bi bi-shield-x me-2"></i>Блокировка IP
+    </a>
 </div>
 
 <table class="table table-striped">

--- a/CloudCityCenter/Controllers/HomeController.cs
+++ b/CloudCityCenter/Controllers/HomeController.cs
@@ -58,7 +58,7 @@ public class HomeController : Controller
     {
         ViewData["StatusCode"] = code;
         ViewData["Title"] = code == StatusCodes.Status403Forbidden
-            ? "Form submission limit reached"
+            ? "Access denied"
             : "Something went wrong";
 
         return View();

--- a/CloudCityCenter/Data/ApplicationDbContext.cs
+++ b/CloudCityCenter/Data/ApplicationDbContext.cs
@@ -18,6 +18,7 @@ public class ApplicationDbContext : IdentityDbContext
     public DbSet<OrderItem> OrderItems { get; set; } = null!;
     public DbSet<Server> Servers { get; set; } = null!;
     public DbSet<ContactMessage> ContactMessages { get; set; } = null!;
+    public DbSet<BlockedIpAddress> BlockedIpAddresses { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -80,6 +81,28 @@ public class ApplicationDbContext : IdentityDbContext
         builder.Entity<Server>()
             .Property(s => s.Stock)
             .HasDefaultValue(9999);
+
+
+        builder.Entity<BlockedIpAddress>()
+            .HasIndex(x => new { x.NormalizedIpAddress, x.IsActive })
+            .IsUnique();
+
+        builder.Entity<BlockedIpAddress>()
+            .Property(x => x.IsActive)
+            .HasDefaultValue(true);
+
+        if (Database.IsSqlServer())
+        {
+            builder.Entity<BlockedIpAddress>()
+                .Property(x => x.CreatedAt)
+                .HasDefaultValueSql("GETUTCDATE()");
+        }
+        else
+        {
+            builder.Entity<BlockedIpAddress>()
+                .Property(x => x.CreatedAt)
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+        }
 
         if (Database.IsSqlServer())
         {

--- a/CloudCityCenter/Middleware/IpBlockMiddleware.cs
+++ b/CloudCityCenter/Middleware/IpBlockMiddleware.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using CloudCityCenter.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace CloudCityCenter.Middleware;
+
+public class IpBlockMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<IpBlockMiddleware> _logger;
+
+    public IpBlockMiddleware(RequestDelegate next, ILogger<IpBlockMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context, ApplicationDbContext dbContext)
+    {
+        if (TryNormalizeIp(context.Connection.RemoteIpAddress, out var normalizedIp))
+        {
+            var isBlocked = await dbContext.BlockedIpAddresses
+                .AsNoTracking()
+                .AnyAsync(x => x.IsActive && x.NormalizedIpAddress == normalizedIp);
+
+            if (isBlocked)
+            {
+                _logger.LogWarning("Blocked request from IP {IpAddress} to {Path}", normalizedIp, context.Request.Path);
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                return;
+            }
+        }
+
+        await _next(context);
+    }
+
+    private static bool TryNormalizeIp(IPAddress? ipAddress, out string normalizedIp)
+    {
+        normalizedIp = string.Empty;
+        if (ipAddress == null)
+        {
+            return false;
+        }
+
+        if (ipAddress.IsIPv4MappedToIPv6)
+        {
+            ipAddress = ipAddress.MapToIPv4();
+        }
+
+        normalizedIp = ipAddress.ToString();
+        return true;
+    }
+}

--- a/CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs
+++ b/CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs
@@ -1,0 +1,88 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CloudCityCenter.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBlockedIpAddresses : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            if (ActiveProvider.Contains("SqlServer"))
+            {
+                migrationBuilder.Sql(
+                    """
+                    IF OBJECT_ID(N'[dbo].[BlockedIpAddresses]', N'U') IS NULL
+                    BEGIN
+                        CREATE TABLE [BlockedIpAddresses] (
+                            [Id] int NOT NULL IDENTITY,
+                            [IpAddress] nvarchar(45) NOT NULL,
+                            [NormalizedIpAddress] nvarchar(45) NOT NULL,
+                            [Reason] nvarchar(500) NULL,
+                            [CreatedAt] datetime2 NOT NULL DEFAULT GETUTCDATE(),
+                            [CreatedBy] nvarchar(256) NULL,
+                            [IsActive] bit NOT NULL DEFAULT CAST(1 AS bit),
+                            CONSTRAINT [PK_BlockedIpAddresses] PRIMARY KEY ([Id])
+                        );
+                    END
+                    """
+                );
+
+                migrationBuilder.Sql(
+                    """
+                    IF NOT EXISTS (
+                        SELECT 1 FROM sys.indexes
+                        WHERE name = 'IX_BlockedIpAddresses_NormalizedIpAddress_IsActive'
+                          AND object_id = OBJECT_ID('BlockedIpAddresses')
+                    )
+                    CREATE UNIQUE INDEX [IX_BlockedIpAddresses_NormalizedIpAddress_IsActive]
+                        ON [BlockedIpAddresses] ([NormalizedIpAddress], [IsActive]);
+                    """
+                );
+
+                return;
+            }
+
+            migrationBuilder.Sql(
+                """
+                CREATE TABLE IF NOT EXISTS "BlockedIpAddresses" (
+                    "Id" INTEGER PRIMARY KEY AUTOINCREMENT,
+                    "IpAddress" TEXT NOT NULL,
+                    "NormalizedIpAddress" TEXT NOT NULL,
+                    "Reason" TEXT NULL,
+                    "CreatedAt" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    "CreatedBy" TEXT NULL,
+                    "IsActive" INTEGER NOT NULL DEFAULT 1
+                );
+                """
+            );
+
+            migrationBuilder.Sql(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS "IX_BlockedIpAddresses_NormalizedIpAddress_IsActive"
+                    ON "BlockedIpAddresses" ("NormalizedIpAddress", "IsActive");
+                """
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            if (ActiveProvider.Contains("SqlServer"))
+            {
+                migrationBuilder.Sql(
+                    """
+                    IF OBJECT_ID(N'[dbo].[BlockedIpAddresses]', N'U') IS NOT NULL
+                        DROP TABLE [BlockedIpAddresses];
+                    """
+                );
+
+                return;
+            }
+
+            migrationBuilder.Sql("DROP TABLE IF EXISTS \"BlockedIpAddresses\";");
+        }
+    }
+}

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -17,6 +17,49 @@ namespace CloudCityCenter.Migrations
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.6");
 
+
+            modelBuilder.Entity("CloudCityCenter.Models.BlockedIpAddress", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT")
+                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+                    b.Property<string>("CreatedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("IpAddress")
+                        .IsRequired()
+                        .HasMaxLength(45)
+                        .HasColumnType("TEXT");
+
+                    b.Property<bool>("IsActive")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(true);
+
+                    b.Property<string>("NormalizedIpAddress")
+                        .IsRequired()
+                        .HasMaxLength(45)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Reason")
+                        .HasMaxLength(500)
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedIpAddress", "IsActive")
+                        .IsUnique();
+
+                    b.ToTable("BlockedIpAddresses");
+                });
+
             modelBuilder.Entity("CloudCityCenter.Models.ContactMessage", b =>
                 {
                     b.Property<int>("Id")

--- a/CloudCityCenter/Models/Admin/BlockedIpCreateViewModel.cs
+++ b/CloudCityCenter/Models/Admin/BlockedIpCreateViewModel.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CloudCityCenter.Models.Admin;
+
+public class BlockedIpCreateViewModel
+{
+    [Required(ErrorMessage = "IP address is required.")]
+    [Display(Name = "IP address")]
+    [StringLength(45)]
+    public string IpAddress { get; set; } = string.Empty;
+
+    [Display(Name = "Reason")]
+    [StringLength(500)]
+    public string? Reason { get; set; }
+}

--- a/CloudCityCenter/Models/BlockedIpAddress.cs
+++ b/CloudCityCenter/Models/BlockedIpAddress.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace CloudCityCenter.Models;
+
+public class BlockedIpAddress
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    [StringLength(45)]
+    public string IpAddress { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(45)]
+    public string NormalizedIpAddress { get; set; } = string.Empty;
+
+    [StringLength(500)]
+    public string? Reason { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [StringLength(256)]
+    public string? CreatedBy { get; set; }
+
+    public bool IsActive { get; set; } = true;
+}

--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Globalization;
 using CloudCityCenter.Data;
 using CloudCityCenter.Services;
+using CloudCityCenter.Middleware;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Localization;
@@ -320,6 +321,7 @@ else
 }
 
 app.UseStatusCodePagesWithReExecute("/Home/StatusCode", "?code={0}");
+app.UseMiddleware<IpBlockMiddleware>();
 
 // Completely disable HTTPS redirection when behind reverse proxy (nginx handles HTTPS)
 // This prevents ERR_TOO_MANY_REDIRECTS errors

--- a/CloudCityCenter/Views/Home/StatusCode.cshtml
+++ b/CloudCityCenter/Views/Home/StatusCode.cshtml
@@ -10,10 +10,10 @@
         @if (isForbidden)
         {
             <p class="lead mb-4">
-                You have reached the form submission limit. Access will be restored automatically after 24 hours.
+                Access to this resource is forbidden. Your request may have been blocked.
             </p>
             <p class="text-muted">
-                If you need immediate assistance, please contact our support team.
+                If you believe this is a mistake, please contact our support team.
             </p>
         }
         else


### PR DESCRIPTION
### Motivation
- Provide admins a simple way to block abusive or unwanted client IPs and prevent requests from those IPs reaching the application.
- Implement the feature in a maintainable, minimally-invasive way using a new DB entity + middleware so behavior works behind reverse proxies.

### Description
- Added a `BlockedIpAddress` entity with `IpAddress`, `NormalizedIpAddress`, `Reason`, `CreatedAt`, `CreatedBy`, and `IsActive` for soft-blocking and normalization of IPv4/IPv6 addresses (`CloudCityCenter/Models/BlockedIpAddress.cs`).
- Wired EF Core support and constraints by adding a `DbSet<BlockedIpAddress>`, a unique index on `(NormalizedIpAddress, IsActive)`, and defaults for `IsActive`/`CreatedAt` in `ApplicationDbContext` and model snapshot.
- Created an admin-only area controller and view models to list, create (with IPv4/IPv6 validation and normalization) and soft-unblock entries (`BlockedIpsController`, `BlockedIpCreateViewModel`, and Razor views under `Areas/Admin/Views/BlockedIps`).
- Implemented `IpBlockMiddleware` which uses `HttpContext.Connection.RemoteIpAddress` (effective because `UseForwardedHeaders()` runs earlier) to deny matching active blocked IPs with `403` and a warning log, and registered it early in the pipeline (`Program.cs`).
- Added a cross-provider EF migration `AddBlockedIpAddresses` that creates the table and unique index for both SQL Server and SQLite, and updated the EF model snapshot; adjusted the 403 `StatusCode` messaging to a generic access-denied text.

### Testing
- Ran repository static check `git diff --check`, which reported no whitespace/patch issues.
- Attempted to run `dotnet ef migrations add` in this environment but tooling is not available (`dotnet: command not found`), so the migration file was authored manually to support both SQL Server and SQLite and should be applied normally in a developer environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89863b228832ba1e61ac4c2c04f32)