### PR TITLE
Expose Blocked IPs admin UI, add navigation and route aliases

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
@@ -19,6 +19,9 @@ public class BlockedIpsController : Controller
         _context = context;
     }
 
+    [HttpGet]
+    [Route("admin/blockedips")]
+    [Route("admin/security/blockedips")]
     public async Task<IActionResult> Index()
     {
         var blockedIps = await _context.BlockedIpAddresses
@@ -36,16 +39,28 @@ public class BlockedIpsController : Controller
 
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create(BlockedIpCreateViewModel model)
+    public async Task<IActionResult> Create(BlockedIpCreateViewModel model, bool returnToIndex = false)
     {
         if (!ModelState.IsValid)
         {
+            if (returnToIndex)
+            {
+                TempData["ErrorMessage"] = "Invalid IP address";
+                return RedirectToAction(nameof(Index));
+            }
+
             return View(model);
         }
 
         if (!TryNormalizeIp(model.IpAddress, out var normalizedIp))
         {
             ModelState.AddModelError(nameof(model.IpAddress), "Please enter a valid IPv4 or IPv6 address.");
+            if (returnToIndex)
+            {
+                TempData["ErrorMessage"] = "Invalid IP address";
+                return RedirectToAction(nameof(Index));
+            }
+
             return View(model);
         }
 
@@ -56,6 +71,11 @@ public class BlockedIpsController : Controller
         {
             TempData["ErrorMessage"] = "IP address already exists";
             ModelState.AddModelError(nameof(model.IpAddress), "This IP address is already blocked.");
+            if (returnToIndex)
+            {
+                return RedirectToAction(nameof(Index));
+            }
+
             return View(model);
         }
 

--- a/CloudCityCenter/Areas/Admin/Views/BlockedIps/Create.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/BlockedIps/Create.cshtml
@@ -7,6 +7,8 @@
 
 <h1>Block IP address</h1>
 
+<partial name="~/Areas/Admin/Views/Shared/_AdminNavigation.cshtml" />
+
 <form asp-area="Admin" asp-controller="BlockedIps" asp-action="Create" method="post" class="mt-4">
     @Html.AntiForgeryToken()
     <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>

--- a/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
@@ -7,13 +7,30 @@
 
 <h1>Blocked IP addresses</h1>
 
-<div class="mb-3 d-flex gap-2 flex-wrap">
-    <a asp-area="Admin" asp-controller="BlockedIps" asp-action="Create" class="btn btn-danger">
-        <i class="bi bi-shield-x me-2"></i>Block IP address
-    </a>
-    <a asp-area="Admin" asp-controller="Products" asp-action="Index" class="btn btn-secondary">
-        <i class="bi bi-arrow-left me-2"></i>Back to admin panel
-    </a>
+<partial name="~/Areas/Admin/Views/Shared/_AdminNavigation.cshtml" />
+
+<div class="card mb-4">
+    <div class="card-body">
+        <h5 class="card-title">Block a new IP address</h5>
+        <form asp-area="Admin" asp-controller="BlockedIps" asp-action="Create" method="post" class="row g-3">
+            @Html.AntiForgeryToken()
+            <div class="col-md-4">
+                <label for="IpAddress" class="form-label">IP address</label>
+                <input id="IpAddress" name="IpAddress" class="form-control" placeholder="e.g. 203.0.113.12 or 2001:db8::10" required />
+            </div>
+            <div class="col-md-6">
+                <label for="Reason" class="form-label">Reason (optional)</label>
+                <input id="Reason" name="Reason" class="form-control" maxlength="500" placeholder="Optional reason" />
+            </div>
+            <input type="hidden" name="returnToIndex" value="true" />
+            <div class="col-md-2 d-flex align-items-end">
+                <button type="submit" class="btn btn-danger w-100">Block IP</button>
+            </div>
+        </form>
+        <div class="mt-2">
+            <a asp-area="Admin" asp-controller="BlockedIps" asp-action="Create" class="btn btn-link px-0">Open full add form</a>
+        </div>
+    </div>
 </div>
 
 @if (TempData["SuccessMessage"] != null)

--- a/CloudCityCenter/Areas/Admin/Views/Messages/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Messages/Index.cshtml
@@ -40,17 +40,7 @@
             }
 
             <!-- Навигация по админ-панели -->
-            <div class="mb-3">
-                <a asp-area="Admin" asp-controller="Products" asp-action="Index" class="btn btn-primary">
-                    <i class="bi bi-box me-2"></i>Товары
-                </a>
-                <a asp-area="Admin" asp-controller="Users" asp-action="NewUsers" class="btn btn-info">
-                    <i class="bi bi-people me-2"></i>Новые пользователи
-                </a>
-                <a asp-area="Admin" asp-controller="Users" asp-action="Customers" class="btn btn-success">
-                    <i class="bi bi-person-check me-2"></i>Клиенты
-                </a>
-            </div>
+            <partial name="~/Areas/Admin/Views/Shared/_AdminNavigation.cshtml" />
 
             <!-- Фильтры -->
             <div class="card mb-4">

--- a/CloudCityCenter/Areas/Admin/Views/Products/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Products/Index.cshtml
@@ -7,21 +7,11 @@
 
 <h1>Управление товарами</h1>
 
+<partial name="~/Areas/Admin/Views/Shared/_AdminNavigation.cshtml" />
+
 <div class="mb-3">
     <a asp-area="Admin" asp-controller="Products" asp-action="Create" class="btn btn-primary">
         <i class="bi bi-plus-circle me-2"></i>Создание товара
-    </a>
-    <a asp-area="Admin" asp-controller="Users" asp-action="NewUsers" class="btn btn-info">
-        <i class="bi bi-people me-2"></i>Новые пользователи
-    </a>
-    <a asp-area="Admin" asp-controller="Users" asp-action="Customers" class="btn btn-success">
-        <i class="bi bi-person-check me-2"></i>Клиенты
-    </a>
-    <a asp-area="Admin" asp-controller="Messages" asp-action="Index" class="btn btn-warning">
-        <i class="bi bi-envelope-fill me-2"></i>Письма
-    </a>
-    <a asp-area="Admin" asp-controller="BlockedIps" asp-action="Index" class="btn btn-danger">
-        <i class="bi bi-shield-x me-2"></i>Блокировка IP
     </a>
 </div>
 

--- a/CloudCityCenter/Areas/Admin/Views/Shared/_AdminNavigation.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Shared/_AdminNavigation.cshtml
@@ -1,0 +1,19 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<div class="mb-3 d-flex gap-2 flex-wrap">
+    <a asp-area="Admin" asp-controller="Products" asp-action="Index" class="btn btn-primary">
+        <i class="bi bi-box me-2"></i>Products
+    </a>
+    <a asp-area="Admin" asp-controller="Users" asp-action="NewUsers" class="btn btn-info">
+        <i class="bi bi-people me-2"></i>New users
+    </a>
+    <a asp-area="Admin" asp-controller="Users" asp-action="Customers" class="btn btn-success">
+        <i class="bi bi-person-check me-2"></i>Customers
+    </a>
+    <a asp-area="Admin" asp-controller="Messages" asp-action="Index" class="btn btn-warning">
+        <i class="bi bi-envelope-fill me-2"></i>Messages
+    </a>
+    <a asp-area="Admin" asp-controller="BlockedIps" asp-action="Index" class="btn btn-danger">
+        <i class="bi bi-shield-x me-2"></i>Blocked IPs
+    </a>
+</div>

--- a/CloudCityCenter/Areas/Admin/Views/Users/Customers.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Users/Customers.cshtml
@@ -7,17 +7,7 @@
 
 <h1>Клиенты</h1>
 
-<div class="mb-3">
-    <a asp-area="Admin" asp-controller="Products" asp-action="Index" class="btn btn-primary">
-        <i class="bi bi-box me-2"></i>Товары
-    </a>
-    <a asp-area="Admin" asp-controller="Users" asp-action="NewUsers" class="btn btn-info">
-        <i class="bi bi-people me-2"></i>Новые пользователи
-    </a>
-    <a asp-area="Admin" asp-controller="Messages" asp-action="Index" class="btn btn-warning">
-        <i class="bi bi-envelope-fill me-2"></i>Письма
-    </a>
-</div>
+<partial name="~/Areas/Admin/Views/Shared/_AdminNavigation.cshtml" />
 
 <table class="table table-striped">
     <thead>

--- a/CloudCityCenter/Areas/Admin/Views/Users/NewUsers.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Users/NewUsers.cshtml
@@ -7,17 +7,7 @@
 
 <h1>Новые пользователи</h1>
 
-<div class="mb-3">
-    <a asp-area="Admin" asp-controller="Products" asp-action="Index" class="btn btn-primary">
-        <i class="bi bi-box me-2"></i>Товары
-    </a>
-    <a asp-area="Admin" asp-controller="Users" asp-action="Customers" class="btn btn-success">
-        <i class="bi bi-person-check me-2"></i>Клиенты
-    </a>
-    <a asp-area="Admin" asp-controller="Messages" asp-action="Index" class="btn btn-warning">
-        <i class="bi bi-envelope-fill me-2"></i>Письма
-    </a>
-</div>
+<partial name="~/Areas/Admin/Views/Shared/_AdminNavigation.cshtml" />
 
 <table class="table table-striped">
     <thead>

--- a/CloudCityCenter/Views/Account/Profile.cshtml
+++ b/CloudCityCenter/Views/Account/Profile.cshtml
@@ -203,6 +203,9 @@
             <a asp-area="Admin" asp-controller="Products" asp-action="Index" class="btn btn-admin">
                 <i class="bi bi-gear me-2"></i>Админ-панель
             </a>
+            <a asp-area="Admin" asp-controller="BlockedIps" asp-action="Index" class="btn btn-admin">
+                <i class="bi bi-shield-x me-2"></i>Блокировка IP
+            </a>
         }
         
         <form asp-controller="Account" asp-action="Logout" method="post" style="display: inline;">


### PR DESCRIPTION
### Motivation
- The Blocked IP feature existed in code but was not easily discoverable in the admin UI because navigation was not consistently surfaced and there were no friendly routes for direct access.
- Administrators need a single, discoverable place to list, add, and remove blocked IPs without jumping between pages.
- Inline add/remove UX and clear feedback are required so admins can manage blocks quickly and safely.

### Description
- Added a reusable admin navigation partial `Areas/Admin/Views/Shared/_AdminNavigation.cshtml` and wired it into key admin pages to surface a visible **Blocked IPs** entry.
- Made the Blocked IPs list page (`Areas/Admin/Views/BlockedIps/Index.cshtml`) the central management UI by adding an inline add form and keeping the dedicated create page for the full form experience.
- Added explicit route aliases in `BlockedIpsController` so the page is reachable at `/admin/blockedips` and `/admin/security/blockedips`, and enhanced the `Create` action to accept a `returnToIndex` flag to support inline submissions with friendly TempData feedback.
- Minor UI wiring: included the admin navigation in `Create.cshtml` and added a shortcut button to the admin section of the user profile (`Views/Account/Profile.cshtml`); confirmed database model, `DbSet`, migration, middleware and pipeline registration were already present and left intact.

### Testing
- Attempted `dotnet build CloudCityCenter.sln` in this environment but it failed with `dotnet: command not found`, so a full build/run test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89bdafa8c832b94ef3cd5358c6d9d)