### PR TITLE
Handle homepage DB query failures to prevent HTTP 500

### DIFF
--- a/CloudCityCenter/Controllers/HomeController.cs
+++ b/CloudCityCenter/Controllers/HomeController.cs
@@ -29,17 +29,27 @@ public class HomeController : Controller
 
     public async Task<IActionResult> Index()
     {
-        var products = await _context.Products
-            .AsNoTracking()
-            .Where(p => p.IsAvailable && p.Type == ProductType.DedicatedServer)
-            .ToListAsync();
-        
+        List<Product> products;
+
+        try
+        {
+            products = await _context.Products
+                .AsNoTracking()
+                .Where(p => p.IsAvailable && p.Type == ProductType.DedicatedServer)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load products for homepage. Returning an empty list to avoid HTTP 500.");
+            products = new List<Product>();
+        }
+
         // SEO оптимизация для главной страницы с локализацией
         var localizer = GetLocalizer();
         ViewData["Title"] = localizer["SEOTitle"].Value;
         ViewData["Description"] = localizer["SEODescription"].Value;
         ViewData["Keywords"] = localizer["SEOKeywords"].Value;
-        
+
         return View(products);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent the homepage from returning HTTP 500 when the `Products` table is unavailable or a database query fails.
- Improve production resilience by failing gracefully and preserving diagnostic information in logs.

### Description
- Wrapped the product-loading query in `HomeController.Index()` in a `try/catch` block and introduced a local `List<Product> products` variable as the result container.
- On exception the controller now logs the error with `_logger.LogError(...)` and falls back to `new List<Product>()` so the view can still render.
- Kept existing SEO/localization behavior (calls to `GetLocalizer()` and `ViewData` assignments) unchanged.
- Change is localized to `CloudCityCenter/Controllers/HomeController.cs` and does not alter routing or other middleware.

### Testing
- Attempted to run `dotnet build CloudCityCenter.sln` in this environment, but `dotnet` is not installed so the build could not be executed (automated build failed due to missing runtime).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8adc1da88832bbe6a944c072dd0d4)