### PR TITLE
Fix AddBlockedIps migration and add middleware fallback to avoid startup 500

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
@@ -24,7 +24,7 @@ public class BlockedIpsController : Controller
     [Route("admin/security/blockedips")]
     public async Task<IActionResult> Index()
     {
-        var blockedIps = await _context.BlockedIpAddresses
+        var blockedIps = await _context.BlockedIps
             .OrderByDescending(x => x.IsActive)
             .ThenByDescending(x => x.CreatedAt)
             .ToListAsync();
@@ -64,7 +64,7 @@ public class BlockedIpsController : Controller
             return View(model);
         }
 
-        var alreadyBlocked = await _context.BlockedIpAddresses
+        var alreadyBlocked = await _context.BlockedIps
             .AnyAsync(x => x.IsActive && x.NormalizedIpAddress == normalizedIp);
 
         if (alreadyBlocked)
@@ -79,7 +79,7 @@ public class BlockedIpsController : Controller
             return View(model);
         }
 
-        var entity = new BlockedIpAddress
+        var entity = new BlockedIp
         {
             IpAddress = model.IpAddress.Trim(),
             NormalizedIpAddress = normalizedIp,
@@ -89,7 +89,7 @@ public class BlockedIpsController : Controller
             IsActive = true
         };
 
-        _context.BlockedIpAddresses.Add(entity);
+        _context.BlockedIps.Add(entity);
         await _context.SaveChangesAsync();
 
         TempData["SuccessMessage"] = "IP address blocked successfully";
@@ -100,7 +100,7 @@ public class BlockedIpsController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Unblock(int id)
     {
-        var entry = await _context.BlockedIpAddresses.FindAsync(id);
+        var entry = await _context.BlockedIps.FindAsync(id);
         if (entry == null)
         {
             TempData["ErrorMessage"] = "Blocked IP was not found";

--- a/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
@@ -1,5 +1,5 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@model IEnumerable<CloudCityCenter.Models.BlockedIpAddress>
+@model IEnumerable<CloudCityCenter.Models.BlockedIp>
 @{
     ViewData["Title"] = "Blocked IP addresses";
     Layout = "~/Views/Shared/_Layout.cshtml";

--- a/CloudCityCenter/Data/ApplicationDbContext.cs
+++ b/CloudCityCenter/Data/ApplicationDbContext.cs
@@ -18,7 +18,7 @@ public class ApplicationDbContext : IdentityDbContext
     public DbSet<OrderItem> OrderItems { get; set; } = null!;
     public DbSet<Server> Servers { get; set; } = null!;
     public DbSet<ContactMessage> ContactMessages { get; set; } = null!;
-    public DbSet<BlockedIpAddress> BlockedIpAddresses { get; set; } = null!;
+    public DbSet<BlockedIp> BlockedIps { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -83,23 +83,26 @@ public class ApplicationDbContext : IdentityDbContext
             .HasDefaultValue(9999);
 
 
-        builder.Entity<BlockedIpAddress>()
+        builder.Entity<BlockedIp>()
+            .ToTable("BlockedIps");
+
+        builder.Entity<BlockedIp>()
             .HasIndex(x => new { x.NormalizedIpAddress, x.IsActive })
             .IsUnique();
 
-        builder.Entity<BlockedIpAddress>()
+        builder.Entity<BlockedIp>()
             .Property(x => x.IsActive)
             .HasDefaultValue(true);
 
         if (Database.IsSqlServer())
         {
-            builder.Entity<BlockedIpAddress>()
+            builder.Entity<BlockedIp>()
                 .Property(x => x.CreatedAt)
                 .HasDefaultValueSql("GETUTCDATE()");
         }
         else
         {
-            builder.Entity<BlockedIpAddress>()
+            builder.Entity<BlockedIp>()
                 .Property(x => x.CreatedAt)
                 .HasDefaultValueSql("CURRENT_TIMESTAMP");
         }

--- a/CloudCityCenter/Middleware/IpBlockMiddleware.cs
+++ b/CloudCityCenter/Middleware/IpBlockMiddleware.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Data;
 using CloudCityCenter.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace CloudCityCenter.Middleware;
 
@@ -8,18 +10,27 @@ public class IpBlockMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly ILogger<IpBlockMiddleware> _logger;
+    private readonly IMemoryCache _memoryCache;
+    private const string BlockedIpsTableExistsCacheKey = "blocked_ips_table_exists";
 
-    public IpBlockMiddleware(RequestDelegate next, ILogger<IpBlockMiddleware> logger)
+    public IpBlockMiddleware(RequestDelegate next, ILogger<IpBlockMiddleware> logger, IMemoryCache memoryCache)
     {
         _next = next;
         _logger = logger;
+        _memoryCache = memoryCache;
     }
 
     public async Task InvokeAsync(HttpContext context, ApplicationDbContext dbContext)
     {
+        if (!await IsBlockedIpsTableAvailableAsync(dbContext))
+        {
+            await _next(context);
+            return;
+        }
+
         if (TryNormalizeIp(context.Connection.RemoteIpAddress, out var normalizedIp))
         {
-            var isBlocked = await dbContext.BlockedIpAddresses
+            var isBlocked = await dbContext.BlockedIps
                 .AsNoTracking()
                 .AnyAsync(x => x.IsActive && x.NormalizedIpAddress == normalizedIp);
 
@@ -32,6 +43,57 @@ public class IpBlockMiddleware
         }
 
         await _next(context);
+    }
+
+    private async Task<bool> IsBlockedIpsTableAvailableAsync(ApplicationDbContext dbContext)
+    {
+        if (_memoryCache.TryGetValue<bool>(BlockedIpsTableExistsCacheKey, out var cachedValue))
+        {
+            return cachedValue;
+        }
+
+        if (!dbContext.Database.IsRelational())
+        {
+            _memoryCache.Set(BlockedIpsTableExistsCacheKey, true, TimeSpan.FromMinutes(5));
+            return true;
+        }
+
+        try
+        {
+            await using var connection = dbContext.Database.GetDbConnection();
+            if (connection.State != ConnectionState.Open)
+            {
+                await connection.OpenAsync();
+            }
+
+            await using var command = connection.CreateCommand();
+            if (dbContext.Database.IsSqlServer())
+            {
+                command.CommandText =
+                    "SELECT CASE WHEN EXISTS (SELECT 1 FROM sys.tables WHERE name = 'BlockedIps' AND schema_id = SCHEMA_ID('dbo')) THEN 1 ELSE 0 END";
+            }
+            else if (dbContext.Database.IsSqlite())
+            {
+                command.CommandText =
+                    "SELECT CASE WHEN EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'BlockedIps') THEN 1 ELSE 0 END";
+            }
+            else
+            {
+                _memoryCache.Set(BlockedIpsTableExistsCacheKey, true, TimeSpan.FromMinutes(5));
+                return true;
+            }
+
+            var existsResult = await command.ExecuteScalarAsync();
+            var exists = Convert.ToInt32(existsResult) == 1;
+            _memoryCache.Set(BlockedIpsTableExistsCacheKey, exists, TimeSpan.FromSeconds(30));
+            return exists;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Skipping IP block check because BlockedIps table availability could not be verified.");
+            _memoryCache.Set(BlockedIpsTableExistsCacheKey, false, TimeSpan.FromSeconds(30));
+            return false;
+        }
     }
 
     private static bool TryNormalizeIp(IPAddress? ipAddress, out string normalizedIp)

--- a/CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs
+++ b/CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -5,84 +6,41 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace CloudCityCenter.Migrations
 {
     /// <inheritdoc />
-    public partial class AddBlockedIpAddresses : Migration
+    public partial class AddBlockedIps : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            if (ActiveProvider.Contains("SqlServer"))
-            {
-                migrationBuilder.Sql(
-                    """
-                    IF OBJECT_ID(N'[dbo].[BlockedIpAddresses]', N'U') IS NULL
-                    BEGIN
-                        CREATE TABLE [BlockedIpAddresses] (
-                            [Id] int NOT NULL IDENTITY,
-                            [IpAddress] nvarchar(45) NOT NULL,
-                            [NormalizedIpAddress] nvarchar(45) NOT NULL,
-                            [Reason] nvarchar(500) NULL,
-                            [CreatedAt] datetime2 NOT NULL DEFAULT GETUTCDATE(),
-                            [CreatedBy] nvarchar(256) NULL,
-                            [IsActive] bit NOT NULL DEFAULT CAST(1 AS bit),
-                            CONSTRAINT [PK_BlockedIpAddresses] PRIMARY KEY ([Id])
-                        );
-                    END
-                    """
-                );
+            migrationBuilder.CreateTable(
+                name: "BlockedIps",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    IpAddress = table.Column<string>(type: "TEXT", maxLength: 45, nullable: false),
+                    NormalizedIpAddress = table.Column<string>(type: "TEXT", maxLength: 45, nullable: false),
+                    Reason = table.Column<string>(type: "TEXT", maxLength: 500, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    CreatedBy = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                    IsActive = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BlockedIps", x => x.Id);
+                });
 
-                migrationBuilder.Sql(
-                    """
-                    IF NOT EXISTS (
-                        SELECT 1 FROM sys.indexes
-                        WHERE name = 'IX_BlockedIpAddresses_NormalizedIpAddress_IsActive'
-                          AND object_id = OBJECT_ID('BlockedIpAddresses')
-                    )
-                    CREATE UNIQUE INDEX [IX_BlockedIpAddresses_NormalizedIpAddress_IsActive]
-                        ON [BlockedIpAddresses] ([NormalizedIpAddress], [IsActive]);
-                    """
-                );
-
-                return;
-            }
-
-            migrationBuilder.Sql(
-                """
-                CREATE TABLE IF NOT EXISTS "BlockedIpAddresses" (
-                    "Id" INTEGER PRIMARY KEY AUTOINCREMENT,
-                    "IpAddress" TEXT NOT NULL,
-                    "NormalizedIpAddress" TEXT NOT NULL,
-                    "Reason" TEXT NULL,
-                    "CreatedAt" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    "CreatedBy" TEXT NULL,
-                    "IsActive" INTEGER NOT NULL DEFAULT 1
-                );
-                """
-            );
-
-            migrationBuilder.Sql(
-                """
-                CREATE UNIQUE INDEX IF NOT EXISTS "IX_BlockedIpAddresses_NormalizedIpAddress_IsActive"
-                    ON "BlockedIpAddresses" ("NormalizedIpAddress", "IsActive");
-                """
-            );
+            migrationBuilder.CreateIndex(
+                name: "IX_BlockedIps_NormalizedIpAddress_IsActive",
+                table: "BlockedIps",
+                columns: new[] { "NormalizedIpAddress", "IsActive" },
+                unique: true);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            if (ActiveProvider.Contains("SqlServer"))
-            {
-                migrationBuilder.Sql(
-                    """
-                    IF OBJECT_ID(N'[dbo].[BlockedIpAddresses]', N'U') IS NOT NULL
-                        DROP TABLE [BlockedIpAddresses];
-                    """
-                );
-
-                return;
-            }
-
-            migrationBuilder.Sql("DROP TABLE IF EXISTS \"BlockedIpAddresses\";");
+            migrationBuilder.DropTable(
+                name: "BlockedIps");
         }
     }
 }

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -18,7 +18,7 @@ namespace CloudCityCenter.Migrations
             modelBuilder.HasAnnotation("ProductVersion", "8.0.6");
 
 
-            modelBuilder.Entity("CloudCityCenter.Models.BlockedIpAddress", b =>
+            modelBuilder.Entity("CloudCityCenter.Models.BlockedIp", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -57,7 +57,7 @@ namespace CloudCityCenter.Migrations
                     b.HasIndex("NormalizedIpAddress", "IsActive")
                         .IsUnique();
 
-                    b.ToTable("BlockedIpAddresses");
+                    b.ToTable("BlockedIps");
                 });
 
             modelBuilder.Entity("CloudCityCenter.Models.ContactMessage", b =>

--- a/CloudCityCenter/Models/BlockedIp.cs
+++ b/CloudCityCenter/Models/BlockedIp.cs
@@ -1,11 +1,9 @@
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace CloudCityCenter.Models;
 
-public class BlockedIpAddress
+public class BlockedIp
 {
-    [Key]
     public int Id { get; set; }
 
     [Required]
@@ -20,7 +18,7 @@ public class BlockedIpAddress
     public string? Reason { get; set; }
 
     [Required]
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime CreatedAt { get; set; }
 
     [StringLength(256)]
     public string? CreatedBy { get; set; }


### PR DESCRIPTION
### Motivation
- The site returned HTTP 500 because the IP-blocking middleware queried a table that failed to be created due to a bad migration that attempted provider-specific schema/IDENTITY changes.  
- The goal is to remove unintended schema drift, make the migration only create the new table and index, and prevent middleware from crashing when the table is missing.  
- Keep the model and DbContext mapping minimal so EF does not attempt identity/column alterations on existing tables.

### Description
- Rewrote the migration to a clean EF migration called `AddBlockedIps` that only `CreateTable("BlockedIps")`, `CreateIndex(...)` and `DropTable("BlockedIps")` in `Up`/`Down` (removed all provider-specific raw SQL and conditional DDL).  
- Renamed/simplified entity to `BlockedIp` and added `DbSet<BlockedIp> BlockedIps` in `ApplicationDbContext`, mapped explicitly to the `BlockedIps` table and configured only the intended index and defaults.  
- Updated EF model snapshot (`ApplicationDbContextModelSnapshot.cs`) and all application code (admin controller and index view) to use `BlockedIp`/`BlockedIps` to avoid name mismatches.  
- Added a defensive check in `IpBlockMiddleware` that verifies (cached via `IMemoryCache`) whether the `BlockedIps` table exists before querying it, and skips blocking logic if the table is not available to keep the site running.  
- Removed the old raw-SQL migration that caused drift and identity alteration attempts and replaced it with the straightforward table/index creation migration.

### Testing
- Attempted a compile/migration run with `dotnet build` / `dotnet` in this environment but `dotnet` is not installed here, so build/migrations could not be executed (`/bin/bash: dotnet: command not found`).  
- Performed static verification: searched repository for stale `BlockedIpAddress`/`BlockedIpAddresses` references and confirmed application code now references `BlockedIp`/`BlockedIps`.  
- Inspected the generated migration and snapshot files to confirm `Up` only creates `BlockedIps` and index and `Down` only drops `BlockedIps`.  
- Committed the changes (`Fix blocked IP migration and middleware fallback`).  

Notes: The root cause was provider-specific, manual DDL in the previous migration which diverged from the EF model and led EF to attempt identity/column changes; that raw SQL was removed and replaced with a clean EF `CreateTable` migration and a middleware guard so the app won't return HTTP 500 if the table is missing until migrations are applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b293c96c832bb540d14e0c21275a)