### PR TITLE
Fix Blocked IP admin feature to match live BlockedIps schema

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
@@ -5,6 +5,7 @@ using CloudCityCenter.Models.Admin;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Data.Common;
 
 namespace CloudCityCenter.Areas.Admin.Controllers;
 
@@ -24,10 +25,19 @@ public class BlockedIpsController : Controller
     [Route("admin/security/blockedips")]
     public async Task<IActionResult> Index()
     {
-        var blockedIps = await _context.BlockedIps
-            .OrderByDescending(x => x.IsActive)
-            .ThenByDescending(x => x.CreatedAt)
-            .ToListAsync();
+        List<BlockedIp> blockedIps;
+        try
+        {
+            blockedIps = await _context.BlockedIps
+                .OrderByDescending(x => x.IsActive)
+                .ThenByDescending(x => x.CreatedAt)
+                .ToListAsync();
+        }
+        catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
+        {
+            TempData["ErrorMessage"] = "Blocked IP list is temporarily unavailable because the BlockedIps table schema is out of sync.";
+            blockedIps = new List<BlockedIp>();
+        }
 
         return View(blockedIps);
     }
@@ -64,8 +74,17 @@ public class BlockedIpsController : Controller
             return View(model);
         }
 
-        var alreadyBlocked = await _context.BlockedIps
-            .AnyAsync(x => x.IsActive && x.NormalizedIpAddress == normalizedIp);
+        bool alreadyBlocked;
+        try
+        {
+            alreadyBlocked = await _context.BlockedIps
+                .AnyAsync(x => x.IsActive && x.IpAddress == normalizedIp);
+        }
+        catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
+        {
+            TempData["ErrorMessage"] = "Blocked IP list is temporarily unavailable because the BlockedIps table schema is out of sync.";
+            return RedirectToAction(nameof(Index));
+        }
 
         if (alreadyBlocked)
         {
@@ -81,16 +100,22 @@ public class BlockedIpsController : Controller
 
         var entity = new BlockedIp
         {
-            IpAddress = model.IpAddress.Trim(),
-            NormalizedIpAddress = normalizedIp,
+            IpAddress = normalizedIp,
             Reason = string.IsNullOrWhiteSpace(model.Reason) ? null : model.Reason.Trim(),
-            CreatedBy = User?.Identity?.Name,
             CreatedAt = DateTime.UtcNow,
             IsActive = true
         };
 
         _context.BlockedIps.Add(entity);
-        await _context.SaveChangesAsync();
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
+        {
+            TempData["ErrorMessage"] = "Could not block IP because the BlockedIps table schema is out of sync.";
+            return RedirectToAction(nameof(Index));
+        }
 
         TempData["SuccessMessage"] = "IP address blocked successfully";
         return RedirectToAction(nameof(Index));
@@ -100,7 +125,16 @@ public class BlockedIpsController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Unblock(int id)
     {
-        var entry = await _context.BlockedIps.FindAsync(id);
+        BlockedIp? entry;
+        try
+        {
+            entry = await _context.BlockedIps.FindAsync(id);
+        }
+        catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
+        {
+            TempData["ErrorMessage"] = "Could not update blocked IP because the BlockedIps table schema is out of sync.";
+            return RedirectToAction(nameof(Index));
+        }
         if (entry == null)
         {
             TempData["ErrorMessage"] = "Blocked IP was not found";
@@ -108,7 +142,15 @@ public class BlockedIpsController : Controller
         }
 
         entry.IsActive = false;
-        await _context.SaveChangesAsync();
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
+        {
+            TempData["ErrorMessage"] = "Could not update blocked IP because the BlockedIps table schema is out of sync.";
+            return RedirectToAction(nameof(Index));
+        }
 
         TempData["SuccessMessage"] = "IP address removed from block list";
         return RedirectToAction(nameof(Index));
@@ -142,4 +184,9 @@ public class BlockedIpsController : Controller
         normalizedIp = ipAddress.ToString();
         return true;
     }
+
+    private static bool IsBlockedIpDataUnavailable(Exception exception) =>
+        exception is DbUpdateException
+            or InvalidOperationException
+            or DbException;
 }

--- a/CloudCityCenter/Data/ApplicationDbContext.cs
+++ b/CloudCityCenter/Data/ApplicationDbContext.cs
@@ -83,29 +83,36 @@ public class ApplicationDbContext : IdentityDbContext
             .HasDefaultValue(9999);
 
 
-        builder.Entity<BlockedIp>()
-            .ToTable("BlockedIps");
-
-        builder.Entity<BlockedIp>()
-            .HasIndex(x => new { x.NormalizedIpAddress, x.IsActive })
-            .IsUnique();
-
-        builder.Entity<BlockedIp>()
-            .Property(x => x.IsActive)
-            .HasDefaultValue(true);
-
-        if (Database.IsSqlServer())
+        builder.Entity<BlockedIp>(entity =>
         {
-            builder.Entity<BlockedIp>()
-                .Property(x => x.CreatedAt)
-                .HasDefaultValueSql("GETUTCDATE()");
-        }
-        else
-        {
-            builder.Entity<BlockedIp>()
-                .Property(x => x.CreatedAt)
-                .HasDefaultValueSql("CURRENT_TIMESTAMP");
-        }
+            entity.ToTable("BlockedIps");
+
+            entity.HasKey(x => x.Id);
+
+            entity.Property(x => x.IpAddress)
+                .IsRequired()
+                .HasMaxLength(45);
+
+            entity.Property(x => x.Reason)
+                .HasMaxLength(500);
+
+            entity.Property(x => x.IsActive)
+                .HasDefaultValue(true);
+
+            entity.HasIndex(x => new { x.IpAddress, x.IsActive })
+                .IsUnique();
+
+            if (Database.IsSqlServer())
+            {
+                entity.Property(x => x.CreatedAt)
+                    .HasDefaultValueSql("GETUTCDATE()");
+            }
+            else
+            {
+                entity.Property(x => x.CreatedAt)
+                    .HasDefaultValueSql("CURRENT_TIMESTAMP");
+            }
+        });
 
         if (Database.IsSqlServer())
         {

--- a/CloudCityCenter/Middleware/IpBlockMiddleware.cs
+++ b/CloudCityCenter/Middleware/IpBlockMiddleware.cs
@@ -37,7 +37,7 @@ public class IpBlockMiddleware
             {
                 isBlocked = await dbContext.BlockedIps
                     .AsNoTracking()
-                    .AnyAsync(x => x.IsActive && x.NormalizedIpAddress == normalizedIp);
+                    .AnyAsync(x => x.IsActive && x.IpAddress == normalizedIp);
             }
             catch (Exception ex) when (IsTransientBlockedIpQueryFailure(ex))
             {

--- a/CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs
+++ b/CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs
@@ -18,10 +18,8 @@ namespace CloudCityCenter.Migrations
                     Id = table.Column<int>(type: "INTEGER", nullable: false)
                         .Annotation("Sqlite:Autoincrement", true),
                     IpAddress = table.Column<string>(type: "TEXT", maxLength: 45, nullable: false),
-                    NormalizedIpAddress = table.Column<string>(type: "TEXT", maxLength: 45, nullable: false),
                     Reason = table.Column<string>(type: "TEXT", maxLength: 500, nullable: true),
                     CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
-                    CreatedBy = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
                     IsActive = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: true)
                 },
                 constraints: table =>
@@ -30,9 +28,9 @@ namespace CloudCityCenter.Migrations
                 });
 
             migrationBuilder.CreateIndex(
-                name: "IX_BlockedIps_NormalizedIpAddress_IsActive",
+                name: "IX_BlockedIps_IpAddress_IsActive",
                 table: "BlockedIps",
-                columns: new[] { "NormalizedIpAddress", "IsActive" },
+                columns: new[] { "IpAddress", "IsActive" },
                 unique: true);
         }
 

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -29,10 +29,6 @@ namespace CloudCityCenter.Migrations
                         .HasColumnType("TEXT")
                         .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("TEXT");
-
                     b.Property<string>("IpAddress")
                         .IsRequired()
                         .HasMaxLength(45)
@@ -43,18 +39,13 @@ namespace CloudCityCenter.Migrations
                         .HasColumnType("INTEGER")
                         .HasDefaultValue(true);
 
-                    b.Property<string>("NormalizedIpAddress")
-                        .IsRequired()
-                        .HasMaxLength(45)
-                        .HasColumnType("TEXT");
-
                     b.Property<string>("Reason")
                         .HasMaxLength(500)
                         .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("NormalizedIpAddress", "IsActive")
+                    b.HasIndex("IpAddress", "IsActive")
                         .IsUnique();
 
                     b.ToTable("BlockedIps");

--- a/CloudCityCenter/Models/BlockedIp.cs
+++ b/CloudCityCenter/Models/BlockedIp.cs
@@ -10,18 +10,11 @@ public class BlockedIp
     [StringLength(45)]
     public string IpAddress { get; set; } = string.Empty;
 
-    [Required]
-    [StringLength(45)]
-    public string NormalizedIpAddress { get; set; } = string.Empty;
-
     [StringLength(500)]
     public string? Reason { get; set; }
 
     [Required]
     public DateTime CreatedAt { get; set; }
-
-    [StringLength(256)]
-    public string? CreatedBy { get; set; }
 
     public bool IsActive { get; set; } = true;
 }


### PR DESCRIPTION
### Motivation
- The admin page and request middleware were failing because the code relied on columns that don't exist in the production `BlockedIps` table (`NormalizedIpAddress`, `CreatedBy`), causing SQL exceptions when loading or modifying blocked IPs. 
- The manually created production table only contains `Id`, `IpAddress`, `Reason`, `CreatedAt`, and `IsActive`, so code and EF mapping must match that schema for stability.

### Description
- Updated the `BlockedIp` entity to match the real table by removing `NormalizedIpAddress` and `CreatedBy` and keeping only `Id`, `IpAddress`, `Reason`, `CreatedAt`, and `IsActive`.
- Reworked EF configuration in `ApplicationDbContext` to explicitly map to `BlockedIps`, enforce `IpAddress` length, `Reason` length, `IsActive` default, and the unique index on `(IpAddress, IsActive)` and to set `CreatedAt` defaults for SQL Server and other providers.
- Changed admin controller (`BlockedIpsController`) to normalize IPs and store the canonical text in `IpAddress`, check duplicates by `IpAddress + IsActive`, remove references to removed columns, and add defensive exception handling that shows a TempData error instead of throwing when the table/schema is unavailable.
- Updated middleware (`IpBlockMiddleware`) to query by `IpAddress` and adjusted the migration and model snapshot (`AddBlockedIpAddresses` and `ApplicationDbContextModelSnapshot`) to remove the non-existent columns and align index names with the live schema.

### Testing
- Attempted an automated build with `dotnet build CloudCityCenter.sln`, but it failed because `dotnet` is not available in this execution environment, so no compile/run tests could be executed here. 
- Migration and model snapshot files were updated to align EF metadata with the real table shape, and code changes were checked locally in the repository (no runtime tests performed due to missing `dotnet`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c04719e0832bb6f46133940b17d2)