### PR TITLE
Make BlockedIps migration provider-aware and clarify DB usage in README

### DIFF
--- a/CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs
+++ b/CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs
@@ -11,21 +11,44 @@ namespace CloudCityCenter.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateTable(
-                name: "BlockedIps",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "INTEGER", nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
-                    IpAddress = table.Column<string>(type: "TEXT", maxLength: 45, nullable: false),
-                    Reason = table.Column<string>(type: "TEXT", maxLength: 500, nullable: true),
-                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
-                    IsActive = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_BlockedIps", x => x.Id);
-                });
+            var isSqlServer = migrationBuilder.ActiveProvider.Contains("SqlServer", StringComparison.OrdinalIgnoreCase);
+
+            if (isSqlServer)
+            {
+                migrationBuilder.CreateTable(
+                    name: "BlockedIps",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(nullable: false)
+                            .Annotation("SqlServer:Identity", "1, 1"),
+                        IpAddress = table.Column<string>(maxLength: 45, nullable: false),
+                        Reason = table.Column<string>(maxLength: 500, nullable: true),
+                        CreatedAt = table.Column<DateTime>(nullable: false, defaultValueSql: "GETUTCDATE()"),
+                        IsActive = table.Column<bool>(nullable: false, defaultValue: true)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_BlockedIps", x => x.Id);
+                    });
+            }
+            else
+            {
+                migrationBuilder.CreateTable(
+                    name: "BlockedIps",
+                    columns: table => new
+                    {
+                        Id = table.Column<int>(nullable: false)
+                            .Annotation("Sqlite:Autoincrement", true),
+                        IpAddress = table.Column<string>(maxLength: 45, nullable: false),
+                        Reason = table.Column<string>(maxLength: 500, nullable: true),
+                        CreatedAt = table.Column<DateTime>(nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                        IsActive = table.Column<bool>(nullable: false, defaultValue: true)
+                    },
+                    constraints: table =>
+                    {
+                        table.PrimaryKey("PK_BlockedIps", x => x.Id);
+                    });
+            }
 
             migrationBuilder.CreateIndex(
                 name: "IX_BlockedIps_IpAddress_IsActive",

--- a/README.md
+++ b/README.md
@@ -140,8 +140,11 @@ Set the `ConnectionStrings__DefaultConnection` value in `CloudCityCenter/appsett
 Or supply it via the `ConnectionStrings__DefaultConnection` environment variable:
 
 ```bash
-export ConnectionStrings__DefaultConnection="Server=localhost\SQLEXPRESS;Database=master;Trusted_Connection=True;"
+export ConnectionStrings__DefaultConnection="Server=localhost\SQLEXPRESS;Database=CloudCityDB;Trusted_Connection=True;"
 ```
+⚠️ Используйте отдельную базу приложения (например, `CloudCityDB`), а не `master`.  
+⚠️ Use a dedicated app database (for example, `CloudCityDB`), not `master`.
+
 Или сохраните её в [секретах пользователя](https://learn.microsoft.com/aspnet/core/security/app-secrets) .NET:
 Or store it using .NET [user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets):
 


### PR DESCRIPTION
### Motivation
- Prevent runtime failures when applying the `AddBlockedIps` migration to SQL Server by replacing SQLite-specific column metadata with provider-aware definitions.
- Ensure the `BlockedIps` table is created in the intended application database rather than `master` by clarifying the README connection-string example.

### Description
- Modified `CloudCityCenter/Migrations/20260422090000_AddBlockedIpAddresses.cs` to detect provider via `migrationBuilder.ActiveProvider.Contains("SqlServer", ...)` and create provider-specific table definitions.
- For SQL Server the migration now uses `SqlServer:Identity` on `Id` and `GETUTCDATE()` as the `CreatedAt` default, while SQLite keeps `Sqlite:Autoincrement` and `CURRENT_TIMESTAMP`.
- Preserved the unique index `IX_BlockedIps_IpAddress_IsActive` and the same column constraints (`maxLength`, `IsActive` default) across providers.
- Updated `README.md` example connection string to use `CloudCityDB` instead of `master` and added an explicit warning to use a dedicated application database.

### Testing
- Attempted to run `dotnet build CloudCityCenter.sln`, but the environment lacks the `dotnet` SDK and the build could not be executed (`/bin/bash: dotnet: command not found`).
- No further automated tests (migrations or `dotnet test`) were run in this environment due to the missing SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c2023858832b935fca6b451e0881)