### PR TITLE
Fix /admin/security/blockedips runtime failures with safe fallback rendering

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
@@ -14,10 +14,12 @@ namespace CloudCityCenter.Areas.Admin.Controllers;
 public class BlockedIpsController : Controller
 {
     private readonly ApplicationDbContext _context;
+    private readonly ILogger<BlockedIpsController> _logger;
 
-    public BlockedIpsController(ApplicationDbContext context)
+    public BlockedIpsController(ApplicationDbContext context, ILogger<BlockedIpsController> logger)
     {
         _context = context;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -25,21 +27,32 @@ public class BlockedIpsController : Controller
     [Route("admin/security/blockedips")]
     public async Task<IActionResult> Index()
     {
-        List<BlockedIp> blockedIps;
         try
         {
-            blockedIps = await _context.BlockedIps
+            var blockedIps = await _context.BlockedIps
+                .AsNoTracking()
                 .OrderByDescending(x => x.IsActive)
                 .ThenByDescending(x => x.CreatedAt)
                 .ToListAsync();
+
+            return View(new BlockedIpsIndexViewModel
+            {
+                Items = blockedIps
+            });
         }
         catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
         {
-            TempData["ErrorMessage"] = "Blocked IP list is temporarily unavailable because the BlockedIps table schema is out of sync.";
-            blockedIps = new List<BlockedIp>();
-        }
+            _logger.LogWarning(ex,
+                "Blocked IP feature is unavailable for {Path}. Returning safe empty state.",
+                HttpContext.Request.Path);
 
-        return View(blockedIps);
+            return View(new BlockedIpsIndexViewModel
+            {
+                IsFeatureInitialized = false,
+                FeatureMessage = "Blocked IP feature is not initialized yet.",
+                Items = Array.Empty<BlockedIp>()
+            });
+        }
     }
 
     public IActionResult Create()
@@ -82,6 +95,8 @@ public class BlockedIpsController : Controller
         }
         catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
         {
+            _logger.LogWarning(ex,
+                "Could not validate blocked IP uniqueness because blocked IP data is unavailable.");
             TempData["ErrorMessage"] = "Blocked IP list is temporarily unavailable because the BlockedIps table schema is out of sync.";
             return RedirectToAction(nameof(Index));
         }
@@ -113,6 +128,8 @@ public class BlockedIpsController : Controller
         }
         catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
         {
+            _logger.LogWarning(ex,
+                "Could not save blocked IP entry because blocked IP data is unavailable.");
             TempData["ErrorMessage"] = "Could not block IP because the BlockedIps table schema is out of sync.";
             return RedirectToAction(nameof(Index));
         }
@@ -132,6 +149,9 @@ public class BlockedIpsController : Controller
         }
         catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
         {
+            _logger.LogWarning(ex,
+                "Could not load blocked IP entry {BlockedIpId} because blocked IP data is unavailable.",
+                id);
             TempData["ErrorMessage"] = "Could not update blocked IP because the BlockedIps table schema is out of sync.";
             return RedirectToAction(nameof(Index));
         }
@@ -148,6 +168,9 @@ public class BlockedIpsController : Controller
         }
         catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
         {
+            _logger.LogWarning(ex,
+                "Could not update blocked IP entry {BlockedIpId} because blocked IP data is unavailable.",
+                id);
             TempData["ErrorMessage"] = "Could not update blocked IP because the BlockedIps table schema is out of sync.";
             return RedirectToAction(nameof(Index));
         }
@@ -187,6 +210,11 @@ public class BlockedIpsController : Controller
 
     private static bool IsBlockedIpDataUnavailable(Exception exception) =>
         exception is DbUpdateException
+            or DbException
             or InvalidOperationException
-            or DbException;
+            or InvalidCastException
+            or FormatException
+            or OverflowException
+            or NullReferenceException
+        || (exception.InnerException is not null && IsBlockedIpDataUnavailable(exception.InnerException));
 }

--- a/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
@@ -1,5 +1,5 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@model IEnumerable<CloudCityCenter.Models.BlockedIp>
+@model CloudCityCenter.Models.Admin.BlockedIpsIndexViewModel
 @{
     ViewData["Title"] = "Blocked IP addresses";
     Layout = "~/Views/Shared/_Layout.cshtml";
@@ -43,43 +43,57 @@
     <div class="alert alert-danger">@TempData["ErrorMessage"]</div>
 }
 
-<table class="table table-striped align-middle">
-    <thead>
-        <tr>
-            <th>IP Address</th>
-            <th>Reason</th>
-            <th>Created date</th>
-            <th>Status</th>
-            <th>Action</th>
-        </tr>
-    </thead>
-    <tbody>
-    @foreach (var item in Model)
-    {
-        <tr>
-            <td><code>@item.IpAddress</code></td>
-            <td>@(string.IsNullOrWhiteSpace(item.Reason) ? "—" : item.Reason)</td>
-            <td>@item.CreatedAt.ToString("u")</td>
-            <td>
-                @if (item.IsActive)
-                {
-                    <span class="badge bg-danger">Active</span>
-                }
-                else
-                {
-                    <span class="badge bg-secondary">Inactive</span>
-                }
-            </td>
-            <td>
-                @if (item.IsActive)
-                {
-                    <form asp-area="Admin" asp-controller="BlockedIps" asp-action="Unblock" asp-route-id="@item.Id" method="post" class="d-inline">
-                        @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-sm btn-outline-success">Unblock</button>
-                    </form>
-                }
-            </td>
-        </tr>
-    }
-    </tbody>
-</table>
+@if (!Model.IsFeatureInitialized)
+{
+    <div class="alert alert-warning">@Model.FeatureMessage</div>
+}
+
+@if (Model.Items.Count == 0)
+{
+    <div class="alert alert-info">No blocked IP addresses found.</div>
+}
+else
+{
+    <table class="table table-striped align-middle">
+        <thead>
+            <tr>
+                <th>IP Address</th>
+                <th>Reason</th>
+                <th>Blocked At</th>
+                <th>Expires At</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var item in Model.Items)
+        {
+            <tr>
+                <td><code>@item.IpAddress</code></td>
+                <td>@(string.IsNullOrWhiteSpace(item.Reason) ? "—" : item.Reason)</td>
+                <td>@item.CreatedAt.ToString("u")</td>
+                <td>—</td>
+                <td>
+                    @if (item.IsActive)
+                    {
+                        <span class="badge bg-danger">Active</span>
+                    }
+                    else
+                    {
+                        <span class="badge bg-secondary">Inactive</span>
+                    }
+                </td>
+                <td>
+                    @if (item.IsActive)
+                    {
+                        <form asp-area="Admin" asp-controller="BlockedIps" asp-action="Unblock" asp-route-id="@item.Id" method="post" class="d-inline">
+                            @Html.AntiForgeryToken()
+                            <button type="submit" class="btn btn-sm btn-outline-success">Unblock</button>
+                        </form>
+                    }
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}

--- a/CloudCityCenter/Models/Admin/BlockedIpsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/BlockedIpsIndexViewModel.cs
@@ -1,0 +1,12 @@
+using CloudCityCenter.Models;
+
+namespace CloudCityCenter.Models.Admin;
+
+public sealed class BlockedIpsIndexViewModel
+{
+    public IReadOnlyList<BlockedIp> Items { get; init; } = Array.Empty<BlockedIp>();
+
+    public bool IsFeatureInitialized { get; init; } = true;
+
+    public string? FeatureMessage { get; init; }
+}


### PR DESCRIPTION
### Motivation
- The `Index` action for `/admin/security/blockedips` assumed blocked-IP persistence was always available and shape-compatible, causing EF/materialization exceptions to bubble up and surface the generic Production error page when the table/schema was missing or out of sync.
- The change ensures the admin page is resilient in production: it should always return a safe view (data or an empty/fallback state) and log useful diagnostics without exposing stack traces to users.

### Description
- Added `BlockedIpsIndexViewModel` (`CloudCityCenter/Models/Admin/BlockedIpsIndexViewModel.cs`) to carry `Items` plus feature-initialized state and an optional `FeatureMessage` for safe rendering.
- Hardened `BlockedIpsController` (`CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs`) to inject `ILogger`, use `AsNoTracking()` and async reads, return the new view model on success, and return a safe fallback view model while logging a warning when blocked-IP data is unavailable.
- Expanded `IsBlockedIpDataUnavailable` to include additional exception types and recursively inspect `InnerException` to detect data/schema-related failures robustly.
- Updated the Razor view (`CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml`) to accept the new view model, render a clear empty-state message, display a feature-not-initialized warning, and render a robust table when records exist (columns: IP Address, Reason, Blocked At, Expires At, Status, Actions).
- No EF schema changes were made, so no migration is required.

### Testing
- Ran `git diff --check` which passed to ensure no whitespace/issues in diffs.
- Verified changes were staged and committed successfully (`git status` / `git commit`).
- Attempted to run `dotnet build` in this environment but it failed because `dotnet` is not installed here, so full build/test automation could not be executed; manual code inspection and local validation recommended before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea04fced34832b88f82ddba3ff4bf0)