### PR TITLE
Harden /admin/security/blockedips — null-safe projection and error logging

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
@@ -27,12 +27,23 @@ public class BlockedIpsController : Controller
     [Route("admin/security/blockedips")]
     public async Task<IActionResult> Index()
     {
+        var requestPath = HttpContext.Request.Path.Value ?? "/admin/security/blockedips";
+        var userName = User?.Identity?.Name ?? "<anonymous>";
+
         try
         {
             var blockedIps = await _context.BlockedIps
                 .AsNoTracking()
+                .Select(x => new BlockedIpListItemViewModel
+                {
+                    Id = EF.Property<int>(x, nameof(BlockedIp.Id)),
+                    IpAddress = EF.Property<string?>(x, nameof(BlockedIp.IpAddress)) ?? "(unknown)",
+                    Reason = EF.Property<string?>(x, nameof(BlockedIp.Reason)),
+                    CreatedAtUtc = EF.Property<DateTime?>(x, nameof(BlockedIp.CreatedAt)),
+                    IsActive = EF.Property<bool?>(x, nameof(BlockedIp.IsActive)) ?? false
+                })
                 .OrderByDescending(x => x.IsActive)
-                .ThenByDescending(x => x.CreatedAt)
+                .ThenByDescending(x => x.CreatedAtUtc)
                 .ToListAsync();
 
             return View(new BlockedIpsIndexViewModel
@@ -40,17 +51,23 @@ public class BlockedIpsController : Controller
                 Items = blockedIps
             });
         }
-        catch (Exception ex) when (IsBlockedIpDataUnavailable(ex))
+        catch (Exception ex)
         {
-            _logger.LogWarning(ex,
-                "Blocked IP feature is unavailable for {Path}. Returning safe empty state.",
-                HttpContext.Request.Path);
+            _logger.LogError(ex,
+                "BlockedIps index failed for {Path}. User={UserName}. Message={Message}. StackTrace={StackTrace}. Inner={InnerMessage}",
+                requestPath,
+                userName,
+                ex.Message,
+                ex.StackTrace,
+                ex.InnerException?.Message);
 
             return View(new BlockedIpsIndexViewModel
             {
                 IsFeatureInitialized = false,
-                FeatureMessage = "Blocked IP feature is not initialized yet.",
-                Items = Array.Empty<BlockedIp>()
+                FeatureMessage = IsBlockedIpDataUnavailable(ex)
+                    ? "Blocked IP feature is not initialized yet."
+                    : "Blocked IP list is temporarily unavailable.",
+                Items = Array.Empty<BlockedIpListItemViewModel>()
             });
         }
     }

--- a/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/BlockedIps/Index.cshtml
@@ -43,12 +43,12 @@
     <div class="alert alert-danger">@TempData["ErrorMessage"]</div>
 }
 
-@if (!Model.IsFeatureInitialized)
+@if (!(Model?.IsFeatureInitialized ?? false))
 {
-    <div class="alert alert-warning">@Model.FeatureMessage</div>
+    <div class="alert alert-warning">@(Model?.FeatureMessage ?? "Blocked IP feature is not initialized yet.")</div>
 }
 
-@if (Model.Items.Count == 0)
+@if ((Model?.Items?.Count ?? 0) == 0)
 {
     <div class="alert alert-info">No blocked IP addresses found.</div>
 }
@@ -66,12 +66,12 @@ else
             </tr>
         </thead>
         <tbody>
-        @foreach (var item in Model.Items)
+        @foreach (var item in Model?.Items ?? Array.Empty<CloudCityCenter.Models.Admin.BlockedIpListItemViewModel>())
         {
             <tr>
                 <td><code>@item.IpAddress</code></td>
                 <td>@(string.IsNullOrWhiteSpace(item.Reason) ? "—" : item.Reason)</td>
-                <td>@item.CreatedAt.ToString("u")</td>
+                <td>@(item.CreatedAtUtc?.ToString("u") ?? "—")</td>
                 <td>—</td>
                 <td>
                     @if (item.IsActive)

--- a/CloudCityCenter/Models/Admin/BlockedIpListItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/BlockedIpListItemViewModel.cs
@@ -1,0 +1,14 @@
+namespace CloudCityCenter.Models.Admin;
+
+public sealed class BlockedIpListItemViewModel
+{
+    public int Id { get; init; }
+
+    public string IpAddress { get; init; } = string.Empty;
+
+    public string? Reason { get; init; }
+
+    public DateTime? CreatedAtUtc { get; init; }
+
+    public bool IsActive { get; init; }
+}

--- a/CloudCityCenter/Models/Admin/BlockedIpsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/BlockedIpsIndexViewModel.cs
@@ -1,10 +1,8 @@
-using CloudCityCenter.Models;
-
 namespace CloudCityCenter.Models.Admin;
 
 public sealed class BlockedIpsIndexViewModel
 {
-    public IReadOnlyList<BlockedIp> Items { get; init; } = Array.Empty<BlockedIp>();
+    public IReadOnlyList<BlockedIpListItemViewModel> Items { get; init; } = Array.Empty<BlockedIpListItemViewModel>();
 
     public bool IsFeatureInitialized { get; init; } = true;
 


### PR DESCRIPTION
### Motivation
- The admin page for `/admin/security/blockedips` was crashing in production due to unhandled exceptions during entity materialization or rendering when DB rows had unexpected/null values or schema issues. 
- The goal is to prevent the generic ASP.NET Core error page by making the controller, view model and Razor view resilient and by adding safe server-side logging for diagnostics.

### Description
- Project `BlockedIp` rows to a new null-tolerant DTO `BlockedIpListItemViewModel` in `BlockedIpsController.Index` using `EF.Property<T>` to avoid fragile entity materialization and to tolerate nullable/malformed values. 
- Add structured error logging in `BlockedIpsController.Index` that records request path, user, exception message, stack trace and inner exception but still returns a safe UI state to users. 
- Replace `BlockedIpsIndexViewModel.Items` type to `IReadOnlyList<BlockedIpListItemViewModel>` and add the new `BlockedIpListItemViewModel` type. 
- Make the Razor view `Areas/Admin/Views/BlockedIps/Index.cshtml` null-safe (guard `Model` and `Items`, use `CreatedAtUtc` and fallback messages) so the page renders empty or shows a friendly feature-unavailable message instead of throwing. 
- No DB schema/migration changes were required because an existing migration for `BlockedIps` already exists.

### Testing
- Ran repository-wide searches to find all references to blocked IPs and confirm controller/view locations using `rg` and examined relevant files. 
- Performed a static check with `git diff --check` which passed. 
- Attempted to build locally with `dotnet build` but the environment lacks the .NET SDK (`dotnet: command not found`), so runtime compilation and live reproduction could not be performed here. 
- Changes were committed locally; runtime validation and capturing any production exception text require deploying this patch and checking production logs for `BlockedIps index failed` entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1d6e6618832ba4381b58b9da5eb0)