### PR TITLE
Handle missing BlockedIps table gracefully in admin page

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
@@ -30,6 +30,17 @@ public class BlockedIpsController : Controller
         var requestPath = HttpContext.Request.Path.Value ?? "/admin/security/blockedips";
         var userName = User?.Identity?.Name ?? "<anonymous>";
 
+
+        if (!await IsBlockedIpsTableAvailableAsync())
+        {
+            return View(new BlockedIpsIndexViewModel
+            {
+                IsFeatureInitialized = false,
+                FeatureMessage = "Blocked IP feature is not initialized yet. Apply the latest database migrations.",
+                Items = Array.Empty<BlockedIpListItemViewModel>()
+            });
+        }
+
         try
         {
             var blockedIps = await _context.BlockedIps
@@ -206,6 +217,39 @@ public class BlockedIpsController : Controller
 
         return IPAddress.TryParse(rawIp.Trim(), out var parsedIp) &&
                TryNormalizeIp(parsedIp, out normalizedIp);
+    }
+
+
+    private async Task<bool> IsBlockedIpsTableAvailableAsync()
+    {
+        try
+        {
+            if (!_context.Database.IsRelational())
+            {
+                return true;
+            }
+
+            var provider = _context.Database.ProviderName ?? string.Empty;
+            if (provider.Contains("SqlServer", StringComparison.OrdinalIgnoreCase))
+            {
+                const string sql = "SELECT CASE WHEN EXISTS (SELECT 1 FROM sys.tables WHERE name = 'BlockedIps' AND schema_id = SCHEMA_ID('dbo')) THEN 1 ELSE 0 END";
+                var result = await _context.Database.SqlQueryRaw<int>(sql).FirstOrDefaultAsync();
+                return result == 1;
+            }
+
+            if (provider.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+            {
+                const string sql = "SELECT CASE WHEN EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'BlockedIps') THEN 1 ELSE 0 END";
+                var result = await _context.Database.SqlQueryRaw<int>(sql).FirstOrDefaultAsync();
+                return result == 1;
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static bool TryNormalizeIp(IPAddress? ipAddress, out string normalizedIp)


### PR DESCRIPTION
### Motivation
- The admin Blocked IPs page crashed when the `BlockedIps` table was missing or the schema was out of sync, causing a generic error instead of a helpful message. 
- The intent is to avoid a runtime exception on page load and give operators clear guidance to apply migrations.

### Description
- Added a pre-check in `BlockedIpsController.Index` that calls a new `IsBlockedIpsTableAvailableAsync()` helper before querying `BlockedIps` and returns a view with `IsFeatureInitialized = false` and a `FeatureMessage` instructing to apply migrations when the table is not available. 
- Implemented provider-specific existence checks for SQL Server and SQLite using raw SQL via `Database.SqlQueryRaw<int>(...)` and `FirstOrDefaultAsync()` to detect the `BlockedIps` table. 
- The helper returns `true` for non-relational providers and returns `false` on errors, so the page degrades safely rather than throwing. 
- Changes are confined to `CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs` and keep existing logging and error-handling paths intact.

### Testing
- `dotnet build CloudCityCenter.sln` was attempted but failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- Local repository checks (`git diff` / commit) were performed to confirm the patch was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a3854274832b86653b7be2ebef42)