### PR TITLE
Enforce blocked IPs using normalized real client IPs (CF-Connecting-IP / X-Forwarded-For)

### DIFF
--- a/CloudCityCenter/Controllers/AboutController.cs
+++ b/CloudCityCenter/Controllers/AboutController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using CloudCityCenter.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
-using System.Linq;
 
 namespace CloudCityCenter.Controllers;
 
@@ -29,17 +28,7 @@ public class AboutController : Controller
 
     private string GetClientIpAddress()
     {
-        var forwardedFor = HttpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
-        if (!string.IsNullOrWhiteSpace(forwardedFor))
-        {
-            var firstForwarded = forwardedFor.Split(',').Select(entry => entry.Trim()).FirstOrDefault();
-            if (!string.IsNullOrWhiteSpace(firstForwarded))
-            {
-                return firstForwarded;
-            }
-        }
-
-        return HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+        return ClientIpResolver.ResolveNormalizedIp(HttpContext) ?? string.Empty;
     }
 
     public IActionResult Index()

--- a/CloudCityCenter/Controllers/ContactController.cs
+++ b/CloudCityCenter/Controllers/ContactController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using CloudCityCenter.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
-using System.Linq;
 
 namespace CloudCityCenter.Controllers
 {
@@ -29,17 +28,7 @@ namespace CloudCityCenter.Controllers
 
         private string GetClientIpAddress()
         {
-            var forwardedFor = HttpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
-            if (!string.IsNullOrWhiteSpace(forwardedFor))
-            {
-                var firstForwarded = forwardedFor.Split(',').Select(entry => entry.Trim()).FirstOrDefault();
-                if (!string.IsNullOrWhiteSpace(firstForwarded))
-                {
-                    return firstForwarded;
-                }
-            }
-
-            return HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+            return ClientIpResolver.ResolveNormalizedIp(HttpContext) ?? string.Empty;
         }
 
         public IActionResult Index()

--- a/CloudCityCenter/Middleware/IpBlockMiddleware.cs
+++ b/CloudCityCenter/Middleware/IpBlockMiddleware.cs
@@ -1,9 +1,9 @@
-using System.Net;
 using System.Data;
 using System.Data.Common;
 using CloudCityCenter.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using CloudCityCenter.Services;
 
 namespace CloudCityCenter.Middleware;
 
@@ -29,7 +29,16 @@ public class IpBlockMiddleware
             return;
         }
 
-        if (TryNormalizeIp(context.Connection.RemoteIpAddress, out var normalizedIp))
+        var normalizedIp = ClientIpResolver.ResolveNormalizedIp(context);
+        _logger.LogInformation("Detected client IP {IpAddress} for request {Path}", normalizedIp ?? "(unknown)", context.Request.Path);
+
+        if (!ShouldCheckBlocking(context))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(normalizedIp))
         {
             bool isBlocked;
 
@@ -53,6 +62,7 @@ public class IpBlockMiddleware
             {
                 _logger.LogWarning("Blocked request from IP {IpAddress} to {Path}", normalizedIp, context.Request.Path);
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await context.Response.WriteAsync("Forbidden");
                 return;
             }
         }
@@ -120,25 +130,34 @@ public class IpBlockMiddleware
         }
     }
 
+    private static bool ShouldCheckBlocking(HttpContext context)
+    {
+        var path = context.Request.Path;
+
+        if (path.StartsWithSegments("/css")
+            || path.StartsWithSegments("/js")
+            || path.StartsWithSegments("/lib")
+            || path.StartsWithSegments("/images")
+            || path.StartsWithSegments("/favicon.ico")
+            || path.StartsWithSegments("/Home/StatusCode"))
+        {
+            return false;
+        }
+
+        if (context.User?.Identity?.IsAuthenticated == true
+            && context.User.IsInRole("Admin")
+            && path.StartsWithSegments("/admin/security/blockedips"))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     private static bool IsTransientBlockedIpQueryFailure(Exception exception) =>
         exception is DbException
             or InvalidOperationException
             or TimeoutException;
 
-    private static bool TryNormalizeIp(IPAddress? ipAddress, out string normalizedIp)
-    {
-        normalizedIp = string.Empty;
-        if (ipAddress == null)
-        {
-            return false;
-        }
 
-        if (ipAddress.IsIPv4MappedToIPv6)
-        {
-            ipAddress = ipAddress.MapToIPv4();
-        }
-
-        normalizedIp = ipAddress.ToString();
-        return true;
-    }
 }

--- a/CloudCityCenter/Services/ClientIpResolver.cs
+++ b/CloudCityCenter/Services/ClientIpResolver.cs
@@ -1,0 +1,66 @@
+using System.Net;
+
+namespace CloudCityCenter.Services;
+
+public static class ClientIpResolver
+{
+    public static string? ResolveNormalizedIp(HttpContext context)
+    {
+        var candidates = new[]
+        {
+            context.Request.Headers["CF-Connecting-IP"].FirstOrDefault(),
+            GetFirstForwardedFor(context.Request.Headers["X-Forwarded-For"].FirstOrDefault()),
+            context.Connection.RemoteIpAddress?.ToString()
+        };
+
+        foreach (var candidate in candidates)
+        {
+            if (TryNormalizeIp(candidate, out var normalizedIp))
+            {
+                return normalizedIp;
+            }
+        }
+
+        return null;
+    }
+
+    public static bool TryNormalizeIp(string? rawIp, out string normalizedIp)
+    {
+        normalizedIp = string.Empty;
+        if (string.IsNullOrWhiteSpace(rawIp))
+        {
+            return false;
+        }
+
+        return IPAddress.TryParse(rawIp.Trim(), out var parsedIp) && TryNormalizeIp(parsedIp, out normalizedIp);
+    }
+
+    public static bool TryNormalizeIp(IPAddress? ipAddress, out string normalizedIp)
+    {
+        normalizedIp = string.Empty;
+        if (ipAddress == null)
+        {
+            return false;
+        }
+
+        if (ipAddress.IsIPv4MappedToIPv6)
+        {
+            ipAddress = ipAddress.MapToIPv4();
+        }
+
+        normalizedIp = ipAddress.ToString();
+        return true;
+    }
+
+    private static string? GetFirstForwardedFor(string? forwardedFor)
+    {
+        if (string.IsNullOrWhiteSpace(forwardedFor))
+        {
+            return null;
+        }
+
+        return forwardedFor
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+    }
+}


### PR DESCRIPTION
### Motivation
- Blocked IPs were being stored but not reliably enforced because the request pipeline sometimes compared against the wrong source address when behind proxies/CDNs.  
- The app needs a single normalized client IP format and priority order so `BlockedIps` checks and form anti-spam use the same value.  
- Requests from blocked addresses must be rejected early with logging while preserving admin unblock and static/error asset behavior.  

### Description
- Added `ClientIpResolver` (`CloudCityCenter/Services/ClientIpResolver.cs`) which resolves and normalizes client IPs, preferring `CF-Connecting-IP`, then the first `X-Forwarded-For` entry, then `HttpContext.Connection.RemoteIpAddress`, and normalizes IPv4-mapped IPv6 addresses.  
- Updated `IpBlockMiddleware` (`CloudCityCenter/Middleware/IpBlockMiddleware.cs`) to use the resolver, log detected client IPs, query `BlockedIps` with `IsActive` + normalized IP, return `403 Forbidden` with a simple body when blocked, and skip checking for static assets/status pages and authenticated admin access to `/admin/security/blockedips`.  
- Updated `ContactController` and `AboutController` to use `ClientIpResolver` for anti-spam/form IP storage so stored form IPs match middleware normalization.  

### Testing
- Attempted to build with `dotnet build CloudCityCenter.sln` but the environment lacks the .NET SDK and the command failed (`dotnet: command not found`), so no automated build/test could be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b0365450832ba93fda06ab4f2d47)