### PR TITLE
Add Analytics admin page and navigation button

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CloudCityCenter.Areas.Admin.Controllers;
+
+[Area("Admin")]
+[Authorize(Roles = "Admin")]
+public class AnalyticsController : Controller
+{
+    public IActionResult Index()
+    {
+        return View();
+    }
+}

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -1,0 +1,6 @@
+@{
+    ViewData["Title"] = "Analytics";
+}
+
+<h1>Analytics</h1>
+<p>Analytics dashboard is working</p>

--- a/CloudCityCenter/Areas/Admin/Views/Shared/_AdminNavigation.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Shared/_AdminNavigation.cshtml
@@ -18,6 +18,9 @@
     <a href="@AdminHref("Messages", "Index", "/Admin/Messages")" class="btn btn-warning">
         <i class="bi bi-envelope-fill me-2"></i>Письма
     </a>
+    <a href="@AdminHref("Analytics", "Index", "/admin/analytics")" class="btn btn-secondary">
+        <i class="bi bi-graph-up me-2"></i>Analytics
+    </a>
     <a href="@AdminHref("BlockedIps", "Index", "/admin/security/blockedips")" class="btn btn-danger">
         <i class="bi bi-shield-x me-2"></i>Заблокированные IP
     </a>


### PR DESCRIPTION
### Motivation
- Provide a basic placeholder analytics dashboard inside the admin area so administrators can access analytics functionality at `/admin/analytics`.
- Make the new page discoverable from the existing admin panel by adding a navigation button next to other admin actions.
- Prepare a minimal controller and view as a foundation for future analytics features.

### Description
- Added `Areas/Admin/Controllers/AnalyticsController.cs` with an `[Area("Admin")]` and `[Authorize(Roles = "Admin")]` controller and an `Index()` action that returns a view.
- Added a Razor view at `Areas/Admin/Views/Analytics/Index.cshtml` which displays the text "Analytics dashboard is working".
- Added an `Analytics` button in the admin navigation in `Areas/Admin/Views/Shared/_AdminNavigation.cshtml` linking to `/admin/analytics` so the page is accessible from the admin panel.

### Testing
- Attempted to run `dotnet build CloudCityCenter.sln`, but the `dotnet` CLI is not available in the execution environment so the automated build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ceab7508832ba92e5bcb40f8325b)