### PR TITLE
Add VisitorSession entity and migration

### DIFF
--- a/CloudCityCenter/Data/ApplicationDbContext.cs
+++ b/CloudCityCenter/Data/ApplicationDbContext.cs
@@ -19,6 +19,7 @@ public class ApplicationDbContext : IdentityDbContext
     public DbSet<Server> Servers { get; set; } = null!;
     public DbSet<ContactMessage> ContactMessages { get; set; } = null!;
     public DbSet<BlockedIp> BlockedIps { get; set; } = null!;
+    public DbSet<VisitorSession> VisitorSessions { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/CloudCityCenter/Migrations/20260505120000_AddVisitorSessions.cs
+++ b/CloudCityCenter/Migrations/20260505120000_AddVisitorSessions.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CloudCityCenter.Migrations
+{
+    public partial class AddVisitorSessions : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "VisitorSessions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    IpAddress = table.Column<string>(type: "TEXT", maxLength: 45, nullable: false),
+                    FirstSeenAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    LastSeenAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VisitorSessions", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "VisitorSessions");
+        }
+    }
+}

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -51,6 +51,29 @@ namespace CloudCityCenter.Migrations
                     b.ToTable("BlockedIps");
                 });
 
+
+            modelBuilder.Entity("CloudCityCenter.Models.VisitorSession", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<DateTime>("FirstSeenAt")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("IpAddress")
+                        .IsRequired()
+                        .HasMaxLength(45)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("LastSeenAt")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("VisitorSessions");
+                });
+
             modelBuilder.Entity("CloudCityCenter.Models.ContactMessage", b =>
                 {
                     b.Property<int>("Id")

--- a/CloudCityCenter/Models/VisitorSession.cs
+++ b/CloudCityCenter/Models/VisitorSession.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CloudCityCenter.Models;
+
+public class VisitorSession
+{
+    public int Id { get; set; }
+
+    [Required]
+    [StringLength(45)]
+    public string IpAddress { get; set; } = string.Empty;
+
+    [Required]
+    public DateTime FirstSeenAt { get; set; }
+
+    [Required]
+    public DateTime LastSeenAt { get; set; }
+}


### PR DESCRIPTION
### Motivation
- Persist basic visitor session data (IP address and first/last seen timestamps) so the application can track anonymous visitors for analytics and security.
- Ensure the database schema includes a `VisitorSessions` table via an EF Core migration so deployments create the table automatically.

### Description
- Added the `VisitorSession` model (`CloudCityCenter/Models/VisitorSession.cs`) with `Id`, `IpAddress`, `FirstSeenAt`, and `LastSeenAt` properties.
- Registered `DbSet<VisitorSession> VisitorSessions` in `ApplicationDbContext` (`CloudCityCenter/Data/ApplicationDbContext.cs`).
- Added an EF Core migration `AddVisitorSessions` (`CloudCityCenter/Migrations/20260505120000_AddVisitorSessions.cs`) which creates the `VisitorSessions` table with the defined columns and a primary key.
- Updated the EF model snapshot (`CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs`) to include the new `VisitorSession` entity mapping.

### Testing
- Attempted to run `cd CloudCityCenter && dotnet ef migrations add AddVisitorSessions`, but the command failed because `dotnet` is not available in this environment (`/bin/bash: dotnet: command not found`).
- No automated database or unit tests were executed here; the migration was created manually and committed so the schema change is ready for environments with the .NET SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d016183c832ba52f61163f67c4a0)