### PR TITLE
Add visitor session tracking and surface visitor list in admin analytics

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using CloudCityCenter.Data;
+using CloudCityCenter.Models.Admin;
 
 namespace CloudCityCenter.Areas.Admin.Controllers;
 
@@ -7,8 +10,29 @@ namespace CloudCityCenter.Areas.Admin.Controllers;
 [Authorize(Roles = "Admin")]
 public class AnalyticsController : Controller
 {
-    public IActionResult Index()
+    private readonly ApplicationDbContext _context;
+
+    public AnalyticsController(ApplicationDbContext context)
     {
-        return View();
+        _context = context;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var visitors = await _context.VisitorSessions
+            .AsNoTracking()
+            .OrderByDescending(x => x.LastSeenAt)
+            .Select(x => new VisitorSessionListItemViewModel
+            {
+                IpAddress = x.IpAddress,
+                FirstSeenAt = x.FirstSeenAt,
+                LastSeenAt = x.LastSeenAt
+            })
+            .ToListAsync();
+
+        return View(new AnalyticsIndexViewModel
+        {
+            Visitors = visitors
+        });
     }
 }

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -1,6 +1,38 @@
+@model CloudCityCenter.Models.Admin.AnalyticsIndexViewModel
+
 @{
     ViewData["Title"] = "Analytics";
 }
 
 <h1>Analytics</h1>
-<p>Analytics dashboard is working</p>
+
+<div class="table-responsive mt-4">
+    <table class="table table-striped table-hover align-middle">
+        <thead>
+            <tr>
+                <th>IP</th>
+                <th>FirstSeenAt (UTC)</th>
+                <th>LastSeenAt (UTC)</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if (Model.Visitors.Count == 0)
+            {
+                <tr>
+                    <td colspan="3" class="text-muted">No visitor sessions yet.</td>
+                </tr>
+            }
+            else
+            {
+                foreach (var visitor in Model.Visitors)
+                {
+                    <tr>
+                        <td><code>@visitor.IpAddress</code></td>
+                        <td>@visitor.FirstSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                        <td>@visitor.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                    </tr>
+                }
+            }
+        </tbody>
+    </table>
+</div>

--- a/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
+++ b/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
@@ -1,0 +1,59 @@
+using CloudCityCenter.Data;
+using CloudCityCenter.Models;
+using CloudCityCenter.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace CloudCityCenter.Middleware;
+
+public class VisitorTrackingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<VisitorTrackingMiddleware> _logger;
+
+    public VisitorTrackingMiddleware(RequestDelegate next, ILogger<VisitorTrackingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context, ApplicationDbContext dbContext)
+    {
+        var normalizedIp = ClientIpResolver.ResolveNormalizedIp(context);
+
+        if (!string.IsNullOrWhiteSpace(normalizedIp))
+        {
+            var nowUtc = DateTime.UtcNow;
+
+            try
+            {
+                var existingSession = await dbContext.VisitorSessions
+                    .FirstOrDefaultAsync(x => x.IpAddress == normalizedIp);
+
+                if (existingSession is null)
+                {
+                    dbContext.VisitorSessions.Add(new VisitorSession
+                    {
+                        IpAddress = normalizedIp,
+                        FirstSeenAt = nowUtc,
+                        LastSeenAt = nowUtc
+                    });
+                }
+                else
+                {
+                    existingSession.LastSeenAt = nowUtc;
+                }
+
+                await dbContext.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Visitor tracking failed for IP {IpAddress} and path {Path}.",
+                    normalizedIp,
+                    context.Request.Path);
+            }
+        }
+
+        await _next(context);
+    }
+}

--- a/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
@@ -1,0 +1,6 @@
+namespace CloudCityCenter.Models.Admin;
+
+public sealed class AnalyticsIndexViewModel
+{
+    public IReadOnlyList<VisitorSessionListItemViewModel> Visitors { get; init; } = Array.Empty<VisitorSessionListItemViewModel>();
+}

--- a/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
@@ -1,0 +1,8 @@
+namespace CloudCityCenter.Models.Admin;
+
+public sealed class VisitorSessionListItemViewModel
+{
+    public string IpAddress { get; init; } = string.Empty;
+    public DateTime FirstSeenAt { get; init; }
+    public DateTime LastSeenAt { get; init; }
+}

--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -330,6 +330,7 @@ if (!useReverseProxy)
 app.UseStaticFiles();
 
 app.UseRequestLocalization(localizationOptions);
+app.UseMiddleware<VisitorTrackingMiddleware>();
 app.UseRouting();
 
 app.UseSession();


### PR DESCRIPTION
### Motivation
- Track visitors in the database so the site can report who visited and when via the `VisitorSessions` table.
- Use the same IP resolution used by blocking logic to ensure consistent IP detection (`ClientIpResolver.ResolveNormalizedIp`).
- Surface visitor IPs and timestamps in the Admin Analytics UI for simple monitoring (IP, `FirstSeenAt`, `LastSeenAt`).

### Description
- Add `VisitorTrackingMiddleware` (`CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs`) which resolves the client IP, creates a new `VisitorSession` with `FirstSeenAt`/`LastSeenAt` on first sighting, and updates `LastSeenAt` on subsequent requests, logging non-fatal failures.
- Register the middleware in the request pipeline by inserting `app.UseMiddleware<VisitorTrackingMiddleware>()` in `Program.cs` before routing so normal requests create/update visitor rows.
- Add strongly-typed admin view models `AnalyticsIndexViewModel` and `VisitorSessionListItemViewModel` under `CloudCityCenter/Models/Admin` to carry the visitor list to the view.
- Update `Areas/Admin/Controllers/AnalyticsController.cs` to load `VisitorSessions` ordered by `LastSeenAt` and update `Areas/Admin/Views/Analytics/Index.cshtml` to display a table with `IP`, `FirstSeenAt`, and `LastSeenAt`.

### Testing
- Attempted `dotnet build CloudCityCenter.sln`, but the build could not run in this environment because the `dotnet` SDK is not installed (build failed with `/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d44757f4832bb0c6ef970fbd04bb)