### PR TITLE
Track PageVisits and add visitor details in Admin Analytics

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -24,9 +24,11 @@ public class AnalyticsController : Controller
             .OrderByDescending(x => x.LastSeenAt)
             .Select(x => new VisitorSessionListItemViewModel
             {
+                Id = x.Id,
                 IpAddress = x.IpAddress,
                 FirstSeenAt = x.FirstSeenAt,
-                LastSeenAt = x.LastSeenAt
+                LastSeenAt = x.LastSeenAt,
+                PagesCount = x.PageVisits.Count
             })
             .ToListAsync();
 
@@ -34,5 +36,37 @@ public class AnalyticsController : Controller
         {
             Visitors = visitors
         });
+    }
+
+    public async Task<IActionResult> Details(int id)
+    {
+        var session = await _context.VisitorSessions
+            .AsNoTracking()
+            .Where(x => x.Id == id)
+            .Select(x => new AnalyticsDetailsViewModel
+            {
+                VisitorSessionId = x.Id,
+                IpAddress = x.IpAddress,
+                FirstSeenAt = x.FirstSeenAt,
+                LastSeenAt = x.LastSeenAt,
+                Visits = x.PageVisits
+                    .OrderByDescending(p => p.VisitedAt)
+                    .Select(p => new PageVisitTimelineItemViewModel
+                    {
+                        VisitedAt = p.VisitedAt,
+                        HttpMethod = p.HttpMethod,
+                        Path = p.Path,
+                        QueryString = p.QueryString
+                    })
+                    .ToList()
+            })
+            .FirstOrDefaultAsync();
+
+        if (session is null)
+        {
+            return NotFound();
+        }
+
+        return View(session);
     }
 }

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Details.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Details.cshtml
@@ -1,0 +1,64 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@model CloudCityCenter.Models.Admin.AnalyticsDetailsViewModel
+
+@{
+    ViewData["Title"] = "Visitor Details";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+}
+
+<div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mb-3">
+    <h1 class="mb-0">Visitor Details</h1>
+    <a asp-action="Index" class="btn btn-outline-secondary">Back to Analytics</a>
+</div>
+
+<partial name="~/Areas/Admin/Views/Shared/_AdminNavigation.cshtml" />
+
+<div class="card mb-4">
+    <div class="card-body">
+        <dl class="row mb-0">
+            <dt class="col-sm-3">IP Address</dt>
+            <dd class="col-sm-9"><code>@Model.IpAddress</code></dd>
+            <dt class="col-sm-3">First Seen UTC</dt>
+            <dd class="col-sm-9">@Model.FirstSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</dd>
+            <dt class="col-sm-3">Last Seen UTC</dt>
+            <dd class="col-sm-9">@Model.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</dd>
+        </dl>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <h5 class="card-title">Visited Pages Timeline</h5>
+
+        @if (!Model.Visits.Any())
+        {
+            <div class="alert alert-info mb-0">No page visits found for this visitor.</div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-striped table-hover align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>VisitedAt UTC</th>
+                            <th>Method</th>
+                            <th>Path</th>
+                            <th>QueryString</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var visit in Model.Visits)
+                        {
+                            <tr>
+                                <td>@visit.VisitedAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                                <td><span class="badge text-bg-light">@visit.HttpMethod</span></td>
+                                <td><code>@visit.Path</code></td>
+                                <td><code>@(string.IsNullOrWhiteSpace(visit.QueryString) ? "—" : visit.QueryString)</code></td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -60,6 +60,8 @@
                             <th>IP Address</th>
                             <th>First Seen UTC</th>
                             <th>Last Seen UTC</th>
+                            <th>Pages Count</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -69,6 +71,10 @@
                                 <td><code>@visitor.IpAddress</code></td>
                                 <td>@visitor.FirstSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                 <td>@visitor.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                                <td>@visitor.PagesCount</td>
+                                <td class="text-end">
+                                    <a asp-action="Details" asp-route-id="@visitor.Id" class="btn btn-sm btn-outline-primary">Details</a>
+                                </td>
                             </tr>
                         }
                     </tbody>

--- a/CloudCityCenter/Data/ApplicationDbContext.cs
+++ b/CloudCityCenter/Data/ApplicationDbContext.cs
@@ -20,6 +20,7 @@ public class ApplicationDbContext : IdentityDbContext
     public DbSet<ContactMessage> ContactMessages { get; set; } = null!;
     public DbSet<BlockedIp> BlockedIps { get; set; } = null!;
     public DbSet<VisitorSession> VisitorSessions { get; set; } = null!;
+    public DbSet<PageVisit> PageVisits { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -82,6 +83,27 @@ public class ApplicationDbContext : IdentityDbContext
         builder.Entity<Server>()
             .Property(s => s.Stock)
             .HasDefaultValue(9999);
+
+        builder.Entity<VisitorSession>()
+            .HasMany(v => v.PageVisits)
+            .WithOne(p => p.VisitorSession)
+            .HasForeignKey(p => p.VisitorSessionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<PageVisit>()
+            .Property(p => p.Path)
+            .HasMaxLength(2048);
+
+        builder.Entity<PageVisit>()
+            .Property(p => p.QueryString)
+            .HasMaxLength(2048);
+
+        builder.Entity<PageVisit>()
+            .Property(p => p.HttpMethod)
+            .HasMaxLength(16);
+
+        builder.Entity<PageVisit>()
+            .HasIndex(p => p.VisitedAt);
 
 
         builder.Entity<BlockedIp>(entity =>

--- a/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
+++ b/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
@@ -7,6 +7,11 @@ namespace CloudCityCenter.Middleware;
 
 public class VisitorTrackingMiddleware
 {
+    private static readonly string[] StaticExtensions =
+    [
+        ".css", ".js", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".webp", ".avif", ".bmp", ".woff", ".woff2", ".ttf", ".eot", ".otf"
+    ];
+
     private readonly RequestDelegate _next;
     private readonly ILogger<VisitorTrackingMiddleware> _logger;
 
@@ -31,16 +36,29 @@ public class VisitorTrackingMiddleware
 
                 if (existingSession is null)
                 {
-                    dbContext.VisitorSessions.Add(new VisitorSession
+                    existingSession = new VisitorSession
                     {
                         IpAddress = normalizedIp,
                         FirstSeenAt = nowUtc,
                         LastSeenAt = nowUtc
-                    });
+                    };
+                    dbContext.VisitorSessions.Add(existingSession);
                 }
                 else
                 {
                     existingSession.LastSeenAt = nowUtc;
+                }
+
+                if (ShouldTrackPageVisit(context.Request.Path))
+                {
+                    dbContext.PageVisits.Add(new PageVisit
+                    {
+                        VisitorSession = existingSession,
+                        Path = context.Request.Path.Value ?? "/",
+                        QueryString = context.Request.QueryString.HasValue ? context.Request.QueryString.Value : null,
+                        HttpMethod = context.Request.Method,
+                        VisitedAt = nowUtc
+                    });
                 }
 
                 await dbContext.SaveChangesAsync();
@@ -55,5 +73,23 @@ public class VisitorTrackingMiddleware
         }
 
         await _next(context);
+    }
+
+    private static bool ShouldTrackPageVisit(PathString path)
+    {
+        var value = path.Value ?? string.Empty;
+
+        if (string.IsNullOrEmpty(value) || value.Equals("/", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (value.StartsWith("/Admin/Analytics", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("/favicon.ico", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !StaticExtensions.Any(ext => value.EndsWith(ext, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/CloudCityCenter/Migrations/20260505123000_AddPageVisits.cs
+++ b/CloudCityCenter/Migrations/20260505123000_AddPageVisits.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CloudCityCenter.Migrations
+{
+    public partial class AddPageVisits : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PageVisits",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    VisitorSessionId = table.Column<int>(type: "INTEGER", nullable: false),
+                    Path = table.Column<string>(type: "TEXT", maxLength: 2048, nullable: false),
+                    QueryString = table.Column<string>(type: "TEXT", maxLength: 2048, nullable: true),
+                    HttpMethod = table.Column<string>(type: "TEXT", maxLength: 16, nullable: false),
+                    VisitedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PageVisits", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PageVisits_VisitorSessions_VisitorSessionId",
+                        column: x => x.VisitorSessionId,
+                        principalTable: "VisitorSessions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageVisits_VisitedAt",
+                table: "PageVisits",
+                column: "VisitedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageVisits_VisitorSessionId",
+                table: "PageVisits",
+                column: "VisitorSessionId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PageVisits");
+        }
+    }
+}

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -52,6 +52,42 @@ namespace CloudCityCenter.Migrations
                 });
 
 
+
+            modelBuilder.Entity("CloudCityCenter.Models.PageVisit", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("HttpMethod")
+                        .IsRequired()
+                        .HasMaxLength(16)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Path")
+                        .IsRequired()
+                        .HasMaxLength(2048)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("QueryString")
+                        .HasMaxLength(2048)
+                        .HasColumnType("TEXT");
+
+                    b.Property<DateTime>("VisitedAt")
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("VisitorSessionId")
+                        .HasColumnType("INTEGER");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("VisitedAt");
+
+                    b.HasIndex("VisitorSessionId");
+
+                    b.ToTable("PageVisits");
+                });
+
             modelBuilder.Entity("CloudCityCenter.Models.VisitorSession", b =>
                 {
                     b.Property<int>("Id")
@@ -127,6 +163,18 @@ namespace CloudCityCenter.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("ContactMessages");
+                });
+
+
+            modelBuilder.Entity("CloudCityCenter.Models.PageVisit", b =>
+                {
+                    b.HasOne("CloudCityCenter.Models.VisitorSession", "VisitorSession")
+                        .WithMany("PageVisits")
+                        .HasForeignKey("VisitorSessionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("VisitorSession");
                 });
 
             modelBuilder.Entity("CloudCityCenter.Models.Order", b =>
@@ -572,6 +620,18 @@ namespace CloudCityCenter.Migrations
                     b.ToTable("AspNetUserTokens", (string)null);
                 });
 
+
+            modelBuilder.Entity("CloudCityCenter.Models.PageVisit", b =>
+                {
+                    b.HasOne("CloudCityCenter.Models.VisitorSession", "VisitorSession")
+                        .WithMany("PageVisits")
+                        .HasForeignKey("VisitorSessionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("VisitorSession");
+                });
+
             modelBuilder.Entity("CloudCityCenter.Models.Order", b =>
                 {
                     b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", "User")
@@ -681,10 +741,28 @@ namespace CloudCityCenter.Migrations
                         .IsRequired();
                 });
 
+
+            modelBuilder.Entity("CloudCityCenter.Models.PageVisit", b =>
+                {
+                    b.HasOne("CloudCityCenter.Models.VisitorSession", "VisitorSession")
+                        .WithMany("PageVisits")
+                        .HasForeignKey("VisitorSessionId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("VisitorSession");
+                });
+
             modelBuilder.Entity("CloudCityCenter.Models.Order", b =>
                 {
                     b.Navigation("Items");
                 });
+
+            modelBuilder.Entity("CloudCityCenter.Models.VisitorSession", b =>
+                {
+                    b.Navigation("PageVisits");
+                });
+
 
             modelBuilder.Entity("CloudCityCenter.Models.Product", b =>
                 {

--- a/CloudCityCenter/Models/Admin/AnalyticsDetailsViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsDetailsViewModel.cs
@@ -1,0 +1,10 @@
+namespace CloudCityCenter.Models.Admin;
+
+public sealed class AnalyticsDetailsViewModel
+{
+    public int VisitorSessionId { get; init; }
+    public string IpAddress { get; init; } = string.Empty;
+    public DateTime FirstSeenAt { get; init; }
+    public DateTime LastSeenAt { get; init; }
+    public IReadOnlyList<PageVisitTimelineItemViewModel> Visits { get; init; } = Array.Empty<PageVisitTimelineItemViewModel>();
+}

--- a/CloudCityCenter/Models/Admin/PageVisitTimelineItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/PageVisitTimelineItemViewModel.cs
@@ -1,0 +1,9 @@
+namespace CloudCityCenter.Models.Admin;
+
+public sealed class PageVisitTimelineItemViewModel
+{
+    public DateTime VisitedAt { get; init; }
+    public string HttpMethod { get; init; } = string.Empty;
+    public string Path { get; init; } = string.Empty;
+    public string? QueryString { get; init; }
+}

--- a/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
@@ -2,7 +2,9 @@ namespace CloudCityCenter.Models.Admin;
 
 public sealed class VisitorSessionListItemViewModel
 {
+    public int Id { get; init; }
     public string IpAddress { get; init; } = string.Empty;
     public DateTime FirstSeenAt { get; init; }
     public DateTime LastSeenAt { get; init; }
+    public int PagesCount { get; init; }
 }

--- a/CloudCityCenter/Models/PageVisit.cs
+++ b/CloudCityCenter/Models/PageVisit.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CloudCityCenter.Models;
+
+public class PageVisit
+{
+    public int Id { get; set; }
+
+    [Required]
+    public int VisitorSessionId { get; set; }
+
+    [Required]
+    [StringLength(2048)]
+    public string Path { get; set; } = string.Empty;
+
+    [StringLength(2048)]
+    public string? QueryString { get; set; }
+
+    [Required]
+    [StringLength(16)]
+    public string HttpMethod { get; set; } = string.Empty;
+
+    [Required]
+    public DateTime VisitedAt { get; set; }
+
+    public VisitorSession VisitorSession { get; set; } = null!;
+}

--- a/CloudCityCenter/Models/VisitorSession.cs
+++ b/CloudCityCenter/Models/VisitorSession.cs
@@ -15,4 +15,6 @@ public class VisitorSession
 
     [Required]
     public DateTime LastSeenAt { get; set; }
+
+    public ICollection<PageVisit> PageVisits { get; set; } = new List<PageVisit>();
 }


### PR DESCRIPTION
### Motivation
- Provide per-visitor page-level tracking so administrators can see which pages each visitor opened and inspect a visit timeline.
- Keep static assets and existing analytics/blocked-IP behavior unchanged while adding the drill-down capability.

### Description
- Added a new `PageVisit` model with `Id`, `VisitorSessionId`, `Path`, `QueryString`, `HttpMethod`, `VisitedAt` and navigation back to `VisitorSession`.
- Extended `VisitorSession` with `ICollection<PageVisit> PageVisits` and added `DbSet<PageVisit>` to `ApplicationDbContext` with relationship and index configuration for `VisitedAt` and `VisitorSessionId`.
- Created EF Core migration `AddPageVisits` and updated the model snapshot to add the `PageVisits` table with a foreign key to `VisitorSessions` and appropriate indexes.
- Updated `VisitorTrackingMiddleware` to find or create a `VisitorSession` by normalized IP, refresh `LastSeenAt`, and create a `PageVisit` per normal page request while skipping static file extensions and `/Admin/Analytics` and `/favicon.ico`; added admin UI changes including `Pages Count` in the list and a `Details` action/view that shows a visit timeline and related view models.

### Testing
- Attempted to run `dotnet ef migrations add AddPageVisits` but the command failed because `dotnet` is not available in this environment.
- The migration file `20260505123000_AddPageVisits.cs` and updated `ApplicationDbContextModelSnapshot` were created/updated manually and are present in the repository.
- No automated unit or integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d9e34860832b811a4d0593a19369)