### PR TITLE
Add Top Pages block to Admin Analytics

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -32,9 +32,25 @@ public class AnalyticsController : Controller
             })
             .ToListAsync();
 
+        var topPages = await _context.PageVisits
+            .AsNoTracking()
+            .Where(x => !x.Path.StartsWith("/Admin/Analytics"))
+            .GroupBy(x => x.Path)
+            .Select(x => new TopPageVisitViewModel
+            {
+                Path = x.Key,
+                VisitsCount = x.Count(),
+                LastVisitAt = x.Max(p => p.VisitedAt)
+            })
+            .OrderByDescending(x => x.VisitsCount)
+            .ThenBy(x => x.Path)
+            .Take(10)
+            .ToListAsync();
+
         return View(new AnalyticsIndexViewModel
         {
-            Visitors = visitors
+            Visitors = visitors,
+            TopPages = topPages
         });
     }
 

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -45,6 +45,41 @@
 
 <div class="card">
     <div class="card-body">
+        <h5 class="card-title">Top Pages</h5>
+
+        @if (Model?.TopPages is null || Model.TopPages.Count == 0)
+        {
+            <div class="alert alert-info mb-0">No page visits found.</div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-striped table-hover align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Page path</th>
+                            <th>Visits count</th>
+                            <th>Last visit time (UTC)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var page in Model.TopPages)
+                        {
+                            <tr>
+                                <td><code>@page.Path</code></td>
+                                <td>@page.VisitsCount</td>
+                                <td>@page.LastVisitAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+<div class="card mt-3">
+    <div class="card-body">
         <h5 class="card-title">Visitor Sessions</h5>
 
         @if (totalSessions == 0)

--- a/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
@@ -3,4 +3,5 @@ namespace CloudCityCenter.Models.Admin;
 public sealed class AnalyticsIndexViewModel
 {
     public IReadOnlyList<VisitorSessionListItemViewModel> Visitors { get; init; } = Array.Empty<VisitorSessionListItemViewModel>();
+    public IReadOnlyList<TopPageVisitViewModel> TopPages { get; init; } = Array.Empty<TopPageVisitViewModel>();
 }

--- a/CloudCityCenter/Models/Admin/TopPageVisitViewModel.cs
+++ b/CloudCityCenter/Models/Admin/TopPageVisitViewModel.cs
@@ -1,0 +1,8 @@
+namespace CloudCityCenter.Models.Admin;
+
+public sealed class TopPageVisitViewModel
+{
+    public string Path { get; init; } = string.Empty;
+    public int VisitsCount { get; init; }
+    public DateTime LastVisitAt { get; init; }
+}


### PR DESCRIPTION
### Motivation
- Provide admins with a quick view of the most visited site pages on the Analytics dashboard by aggregating `PageVisits` by `Path` and showing visit counts and recency. 
- Limit the output to the top 10 pages and avoid counting the analytics pages themselves to keep the results meaningful. 

### Description
- Added `TopPageVisitViewModel` with `Path`, `VisitsCount`, and `LastVisitAt` to represent aggregated page metrics. 
- Extended `AnalyticsIndexViewModel` with a `TopPages` collection to carry the aggregated results to the view. 
- In `AnalyticsController.Index` added an `AsNoTracking()` LINQ query against `PageVisits` that excludes paths starting with `/Admin/Analytics`, groups by `Path`, computes count and last-visit time, orders by count, and takes the top 10. 
- Updated `Areas/Admin/Views/Analytics/Index.cshtml` to render a Bootstrap card/table titled "Top Pages" with columns for Page path, Visits count, and Last visit time (UTC), including empty-state handling. 

### Testing
- Attempted to run `dotnet build CloudCityCenter.sln`, which failed in this environment because `dotnet` is not available (`/bin/bash: dotnet: command not found`). 
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9dbaa6340832bbeef6a6b9fe8a259)