### PR TITLE
Fix Razor directive issues in Admin Analytics view

### DIFF
--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -1,13 +1,14 @@
-@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@model CloudCityCenter.Models.Admin.AnalyticsIndexViewModel
+@model IEnumerable<CloudCityCenter.Models.VisitorSession>
 
 @{
-    ViewData["Title"] = "Analytics Dashboard";
-    Layout = "~/Views/Shared/_Layout.cshtml";
+    ViewData["Title"] = "Analytics";
+}
 
-    var totalSessions = Model?.Visitors?.Count ?? 0;
-    var uniqueIpAddresses = Model?.Visitors?.Select(v => v.IpAddress).Where(ip => !string.IsNullOrWhiteSpace(ip)).Distinct(StringComparer.OrdinalIgnoreCase).Count() ?? 0;
-    var lastVisitorTime = Model?.Visitors?.OrderByDescending(v => v.LastSeenAt).FirstOrDefault()?.LastSeenAt;
+@{
+    var analyticsModel = ViewData.Model as CloudCityCenter.Models.Admin.AnalyticsIndexViewModel;
+    var totalSessions = analyticsModel?.Visitors?.Count ?? 0;
+    var uniqueIpAddresses = analyticsModel?.Visitors?.Select(v => v.IpAddress).Where(ip => !string.IsNullOrWhiteSpace(ip)).Distinct(StringComparer.OrdinalIgnoreCase).Count() ?? 0;
+    var lastVisitorTime = analyticsModel?.Visitors?.OrderByDescending(v => v.LastSeenAt).FirstOrDefault()?.LastSeenAt;
 }
 
 <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mb-3">
@@ -47,7 +48,7 @@
     <div class="card-body">
         <h5 class="card-title">Top Pages</h5>
 
-        @if (Model?.TopPages is null || Model.TopPages.Count == 0)
+        @if (analyticsModel?.TopPages is null || analyticsModel.TopPages.Count == 0)
         {
             <div class="alert alert-info mb-0">No page visits found.</div>
         }
@@ -63,7 +64,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var page in Model.TopPages)
+                        @foreach (var page in analyticsModel.TopPages)
                         {
                             <tr>
                                 <td><code>@page.Path</code></td>
@@ -100,7 +101,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var visitor in Model?.Visitors ?? Array.Empty<CloudCityCenter.Models.Admin.VisitorSessionListItemViewModel>())
+                        @foreach (var visitor in analyticsModel?.Visitors ?? Array.Empty<CloudCityCenter.Models.Admin.VisitorSessionListItemViewModel>())
                         {
                             <tr>
                                 <td><code>@visitor.IpAddress</code></td>


### PR DESCRIPTION
### Motivation
- The Analytics view contained Razor Pages-style header directives which cause Razor errors (e.g. `RZ2005`, `RZ1011`, `RZ2001`) in this ASP.NET MVC project. 

### Description
- Replaced the existing header with `@model IEnumerable<CloudCityCenter.Models.VisitorSession>` and set `ViewData["Title"] = "Analytics"` so the view uses an MVC-compatible top-of-file. 
- Introduced a local cast `var analyticsModel = ViewData.Model as CloudCityCenter.Models.Admin.AnalyticsIndexViewModel;` and rewrote the view bindings to use `analyticsModel` for the existing dashboard data. 
- Removed Razor Pages-specific top-line usage (previous `@addTagHelper`/page-model header) and preserved all existing HTML markup, tables, and layout structure.

### Testing
- Ran `dotnet build CloudCityCenter.sln` which could not complete because the `dotnet` CLI is not installed in this environment (failed). 
- Ran `dotnet publish CloudCityCenter.sln` which could not complete because the `dotnet` CLI is not installed in this environment (failed). 
- Verified the modified file content and bindings locally in the repo by inspecting the updated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e0badd0c832b89c8551d6db7580a)