### PR TITLE
Fix Admin Analytics Index MVC view model wiring

### DIFF
--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -1,14 +1,18 @@
-@model IEnumerable<CloudCityCenter.Models.VisitorSession>
+@model CloudCityCenter.Models.Admin.AnalyticsIndexViewModel
 
 @{
     ViewData["Title"] = "Analytics";
-}
 
-@{
-    var analyticsModel = ViewData.Model as CloudCityCenter.Models.Admin.AnalyticsIndexViewModel;
-    var totalSessions = analyticsModel?.Visitors?.Count ?? 0;
-    var uniqueIpAddresses = analyticsModel?.Visitors?.Select(v => v.IpAddress).Where(ip => !string.IsNullOrWhiteSpace(ip)).Distinct(StringComparer.OrdinalIgnoreCase).Count() ?? 0;
-    var lastVisitorTime = analyticsModel?.Visitors?.OrderByDescending(v => v.LastSeenAt).FirstOrDefault()?.LastSeenAt;
+    var totalSessions = Model.Visitors.Count;
+    var uniqueIpAddresses = Model.Visitors
+        .Select(v => v.IpAddress)
+        .Where(ip => !string.IsNullOrWhiteSpace(ip))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .Count();
+    var lastVisitorTime = Model.Visitors
+        .OrderByDescending(v => v.LastSeenAt)
+        .FirstOrDefault()
+        ?.LastSeenAt;
 }
 
 <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mb-3">
@@ -48,7 +52,7 @@
     <div class="card-body">
         <h5 class="card-title">Top Pages</h5>
 
-        @if (analyticsModel?.TopPages is null || analyticsModel.TopPages.Count == 0)
+        @if (Model.TopPages.Count == 0)
         {
             <div class="alert alert-info mb-0">No page visits found.</div>
         }
@@ -64,7 +68,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var page in analyticsModel.TopPages)
+                        @foreach (var page in Model.TopPages)
                         {
                             <tr>
                                 <td><code>@page.Path</code></td>
@@ -101,7 +105,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var visitor in analyticsModel?.Visitors ?? Array.Empty<CloudCityCenter.Models.Admin.VisitorSessionListItemViewModel>())
+                        @foreach (var visitor in Model.Visitors)
                         {
                             <tr>
                                 <td><code>@visitor.IpAddress</code></td>


### PR DESCRIPTION
### Motivation
- The Analytics MVC view was using the wrong model type and a cast of `ViewData.Model`, causing a mismatch with the controller-provided `AnalyticsIndexViewModel` and potential runtime errors. 
- The view needed to be converted to a single strongly-typed MVC view (no Razor Pages `@page` usage) and to consume the view model properties directly.

### Description
- Replaced the top-of-file model directive with `@model CloudCityCenter.Models.Admin.AnalyticsIndexViewModel` in `CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml` and ensured there is only one `@model` directive. 
- Removed the `ViewData.Model` cast and switched analytics calculations to use `Model` directly (total sessions, unique IPs, last visitor time). 
- Updated the Top Pages loop to iterate `Model.TopPages` and the Visitor Sessions loop to iterate `Model.Visitors`. 
- Ensured the view references the real view-model properties (`Visitors`, `TopPages`) and retained MVC-compatible Razor syntax (no `@page` directives added).

### Testing
- Attempted `dotnet build` but it could not run in this environment because the `dotnet` CLI is not installed (`bash: command not found: dotnet`).
- Attempted `dotnet publish` but it also could not run for the same environment limitation.
- Verified the updated file contents locally in the repository to ensure the model directive and loops reference the correct properties.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e2bf1c08832b8069bfdf3bdacb22)