### PR TITLE
Fix Admin Analytics navigation highlighting and visitor session Details links

### DIFF
--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Details.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Details.cshtml
@@ -22,6 +22,8 @@
             <dd class="col-sm-9">@Model.FirstSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</dd>
             <dt class="col-sm-3">Last Seen UTC</dt>
             <dd class="col-sm-9">@Model.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</dd>
+            <dt class="col-sm-3">Pages Count</dt>
+            <dd class="col-sm-9">@Model.Visits.Count</dd>
         </dl>
     </div>
 </div>

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -117,7 +117,7 @@
                                             <td>@visitor.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.PagesCount</td>
                                             <td class="text-end">
-                                                <a asp-action="Details" asp-route-id="@visitor.Id" class="btn btn-sm btn-primary">Details</a>
+                                                <a href="@Url.Action("Details", "Analytics", new { area = "Admin", id = visitor.Id })" class="btn btn-sm btn-primary">Details</a>
                                             </td>
                                         </tr>
                                     }

--- a/CloudCityCenter/Areas/Admin/Views/Shared/_AdminNavigation.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Shared/_AdminNavigation.cshtml
@@ -1,27 +1,38 @@
-@{
+@{ 
+    var currentController = ViewContext.RouteData.Values["controller"]?.ToString();
+    var currentAction = ViewContext.RouteData.Values["action"]?.ToString();
+
     string AdminHref(string controller, string action, string fallback)
     {
         return Url.Action(action, controller, new { area = "Admin" }) ?? fallback;
     }
+
+    string NavButtonClass(string controller, string action, string defaultClass)
+    {
+        var isActive = string.Equals(currentController, controller, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(currentAction, action, StringComparison.OrdinalIgnoreCase);
+
+        return isActive ? "btn btn-dark" : $"btn {defaultClass}";
+    }
 }
 
 <div class="mb-3 d-flex gap-2 flex-wrap">
-    <a href="@AdminHref("Products", "Create", "/Admin/Products/Create")" class="btn btn-primary">
+    <a href="@AdminHref("Products", "Create", "/Admin/Products/Create")" class="@NavButtonClass("Products", "Create", "btn-primary")">
         <i class="bi bi-plus-circle me-2"></i>Создание товара
     </a>
-    <a href="@AdminHref("Users", "NewUsers", "/Admin/Users/NewUsers")" class="btn btn-info">
+    <a href="@AdminHref("Users", "NewUsers", "/Admin/Users/NewUsers")" class="@NavButtonClass("Users", "NewUsers", "btn-info")">
         <i class="bi bi-people me-2"></i>Новые пользователи
     </a>
-    <a href="@AdminHref("Users", "Customers", "/Admin/Users/Customers")" class="btn btn-success">
+    <a href="@AdminHref("Users", "Customers", "/Admin/Users/Customers")" class="@NavButtonClass("Users", "Customers", "btn-success")">
         <i class="bi bi-person-check me-2"></i>Клиенты
     </a>
-    <a href="@AdminHref("Messages", "Index", "/Admin/Messages")" class="btn btn-warning">
+    <a href="@AdminHref("Messages", "Index", "/Admin/Messages")" class="@NavButtonClass("Messages", "Index", "btn-warning")">
         <i class="bi bi-envelope-fill me-2"></i>Письма
     </a>
-    <a href="@AdminHref("Analytics", "Index", "/admin/analytics")" class="btn btn-secondary">
+    <a href="@AdminHref("Analytics", "Index", "/admin/analytics")" class="@NavButtonClass("Analytics", "Index", "btn-secondary")">
         <i class="bi bi-graph-up me-2"></i>Analytics
     </a>
-    <a href="@AdminHref("BlockedIps", "Index", "/admin/security/blockedips")" class="btn btn-danger">
+    <a href="@AdminHref("BlockedIps", "Index", "/admin/security/blockedips")" class="@NavButtonClass("BlockedIps", "Index", "btn-danger")">
         <i class="bi bi-shield-x me-2"></i>Заблокированные IP
     </a>
 </div>


### PR DESCRIPTION
### Motivation
- The Analytics page did not display the shared admin navigation with the same active-state behavior as other admin pages, and the Visitor Sessions `Details` button did not reliably route to the correct session details URL.

### Description
- Updated `Areas/Admin/Views/Shared/_AdminNavigation.cshtml` to compute `currentController` and `currentAction` and added `NavButtonClass(...)` to apply an active `btn btn-dark` style for the current admin page.
- Fixed the Visitor Sessions `Details` link in `Areas/Admin/Views/Analytics/Index.cshtml` to use `@Url.Action("Details", "Analytics", new { area = "Admin", id = visitor.Id })` so each row links to `/Admin/Analytics/Details/{id}`.
- Added `Pages Count` display to `Areas/Admin/Views/Analytics/Details.cshtml` so the details page shows the number of visited pages in the session summary.
- No controller or database schema changes were required because `AnalyticsController.Details(int id)` already loads the selected `VisitorSession` with its `PageVisits` and returns `NotFound()` when not found.

### Testing
- Attempted `dotnet publish CloudCityCenter/CloudCityCenter.csproj -c Release` which failed in this environment because `dotnet` is not installed.
- Verified by code inspection that the `Details` link now generates an explicit `/Admin/Analytics/Details/{id}` URL and that the shared navigation will render an active button for the current route.
- No automated unit/integration tests were executed due to the unavailable `dotnet` tool in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e94896d8832b87f4e1b4e7844ae6)