### PR TITLE
Add IP address search to Admin Analytics

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -17,9 +17,10 @@ public class AnalyticsController : Controller
         _context = context;
     }
 
-    public async Task<IActionResult> Index(string? range = "today", DateTime? startDate = null, DateTime? endDate = null)
+    public async Task<IActionResult> Index(string? range = "today", DateTime? startDate = null, DateTime? endDate = null, string? ipAddress = null)
     {
         var selectedRange = (range ?? "today").Trim().ToLowerInvariant();
+        var searchIpAddress = (ipAddress ?? string.Empty).Trim();
         var utcToday = DateTime.UtcNow.Date;
 
         DateTime filterStart;
@@ -57,9 +58,17 @@ public class AnalyticsController : Controller
             filterEndExclusive = utcToday.AddDays(1);
         }
 
-        var visitors = await _context.VisitorSessions
+        var visitorSessionsQuery = _context.VisitorSessions
             .AsNoTracking()
-            .Where(x => x.LastSeenAt >= filterStart && x.LastSeenAt < filterEndExclusive)
+            .Where(x => x.LastSeenAt >= filterStart && x.LastSeenAt < filterEndExclusive);
+
+        if (!string.IsNullOrWhiteSpace(searchIpAddress))
+        {
+            visitorSessionsQuery = visitorSessionsQuery
+                .Where(x => x.IpAddress.Contains(searchIpAddress));
+        }
+
+        var visitors = await visitorSessionsQuery
             .OrderByDescending(x => x.LastSeenAt)
             .Select(x => new VisitorSessionListItemViewModel
             {
@@ -95,6 +104,7 @@ public class AnalyticsController : Controller
         return View(new AnalyticsIndexViewModel
         {
             SelectedFilter = selectedRange,
+            SearchIpAddress = searchIpAddress,
             StartDateUtc = filterStart,
             EndDateUtc = filterEndExclusive.AddTicks(-1),
             TotalPageVisits = totalPageVisits,

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -39,6 +39,10 @@
                         <input class="form-control" type="date" id="endDate" name="endDate" value="@Model.EndDateUtc?.ToString("yyyy-MM-dd")" />
                     </div>
                     <div class="col-12 col-md-3">
+                        <label class="form-label" for="ipAddress">IP address</label>
+                        <input class="form-control" type="text" id="ipAddress" name="ipAddress" value="@Model.SearchIpAddress" placeholder="e.g. 203.0.113.10" />
+                    </div>
+                    <div class="col-12 col-md-3">
                         <button type="submit" class="btn btn-primary w-100">Apply filter</button>
                     </div>
                 </div>
@@ -116,7 +120,14 @@
 
                     @if (totalSessions == 0)
                     {
-                        <div class="alert alert-info mb-0">No visitor sessions found.</div>
+                        @if (!string.IsNullOrWhiteSpace(Model.SearchIpAddress))
+                        {
+                            <div class="alert alert-info mb-0">No visitor sessions found for IP address <code>@Model.SearchIpAddress</code>.</div>
+                        }
+                        else
+                        {
+                            <div class="alert alert-info mb-0">No visitor sessions found.</div>
+                        }
                     }
                     else
                     {

--- a/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
@@ -3,6 +3,7 @@ namespace CloudCityCenter.Models.Admin;
 public sealed class AnalyticsIndexViewModel
 {
     public string SelectedFilter { get; init; } = "today";
+    public string SearchIpAddress { get; init; } = string.Empty;
     public DateTime? StartDateUtc { get; init; }
     public DateTime? EndDateUtc { get; init; }
     public int TotalPageVisits { get; init; }


### PR DESCRIPTION
### Motivation
- Allow administrators to search visitor history by IP address in the Analytics dashboard. 
- Preserve existing page visits, top pages, and visitor details behavior while providing a clear empty-state message when a search yields no sessions.

### Description
- Added an `ipAddress` query parameter to `AnalyticsController.Index` and normalize it to `searchIpAddress` for filtering. 
- Applied the IP filter to the `VisitorSessions` query with `Where(x => x.IpAddress.Contains(searchIpAddress))` while keeping the date-range filtering intact. 
- Added `SearchIpAddress` to `AnalyticsIndexViewModel` so the entered value is preserved and round-tripped to the view. 
- Updated `Areas/Admin/Views/Analytics/Index.cshtml` to include a text input for `ipAddress` and show a specific message when no visitor sessions match the searched IP.

### Testing
- Attempted to run `dotnet build CloudCityCenter.sln`, but the command failed because `dotnet` is not available in the current environment. No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f09e1d5c832bbd524ed7be47e0c4)