### PR TITLE
Track and display visitor User-Agent in analytics

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -76,7 +76,8 @@ public class AnalyticsController : Controller
                 IpAddress = x.IpAddress,
                 FirstSeenAt = x.FirstSeenAt,
                 LastSeenAt = x.LastSeenAt,
-                PagesCount = x.PageVisits.Count
+                PagesCount = x.PageVisits.Count,
+                UserAgent = x.UserAgent
             })
             .ToListAsync();
 
@@ -124,6 +125,7 @@ public class AnalyticsController : Controller
                 IpAddress = x.IpAddress,
                 FirstSeenAt = x.FirstSeenAt,
                 LastSeenAt = x.LastSeenAt,
+                UserAgent = x.UserAgent,
                 Visits = x.PageVisits
                     .OrderByDescending(p => p.VisitedAt)
                     .Select(p => new PageVisitTimelineItemViewModel

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Details.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Details.cshtml
@@ -24,6 +24,8 @@
             <dd class="col-sm-9">@Model.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</dd>
             <dt class="col-sm-3">Pages Count</dt>
             <dd class="col-sm-9">@Model.Visits.Count</dd>
+            <dt class="col-sm-3">User-Agent</dt>
+            <dd class="col-sm-9"><code class="text-wrap">@(string.IsNullOrWhiteSpace(Model.UserAgent) ? "—" : Model.UserAgent)</code></dd>
         </dl>
     </div>
 </div>

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -1,5 +1,21 @@
 @model CloudCityCenter.Models.Admin.AnalyticsIndexViewModel
 
+
+@functions {
+    private static string FormatShortUserAgent(string? userAgent)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return "—";
+        }
+
+        const int maxLength = 60;
+        return userAgent.Length <= maxLength
+            ? userAgent
+            : $"{userAgent[..maxLength]}…";
+    }
+}
+
 @{
     ViewData["Title"] = "Analytics";
     Layout = "~/Views/Shared/_Layout.cshtml";
@@ -139,6 +155,7 @@
                                         <th>First Seen UTC</th>
                                         <th>Last Seen UTC</th>
                                         <th>Pages Count</th>
+                                        <th>User-Agent</th>
                                         <th></th>
                                     </tr>
                                 </thead>
@@ -150,6 +167,7 @@
                                             <td>@visitor.FirstSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.PagesCount</td>
+                                            <td><span title="@visitor.UserAgent">@FormatShortUserAgent(visitor.UserAgent)</span></td>
                                             <td class="text-end">
                                                 <a href="@Url.Action("Details", "Analytics", new { area = "Admin", id = visitor.Id })" class="btn btn-sm btn-primary">Details</a>
                                             </td>

--- a/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
+++ b/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
@@ -28,6 +28,7 @@ public class VisitorTrackingMiddleware
         if (!string.IsNullOrWhiteSpace(normalizedIp))
         {
             var nowUtc = DateTime.UtcNow;
+            var userAgent = ResolveUserAgent(context);
 
             try
             {
@@ -40,13 +41,19 @@ public class VisitorTrackingMiddleware
                     {
                         IpAddress = normalizedIp,
                         FirstSeenAt = nowUtc,
-                        LastSeenAt = nowUtc
+                        LastSeenAt = nowUtc,
+                        UserAgent = userAgent
                     };
                     dbContext.VisitorSessions.Add(existingSession);
                 }
                 else
                 {
                     existingSession.LastSeenAt = nowUtc;
+
+                    if (!string.IsNullOrWhiteSpace(userAgent))
+                    {
+                        existingSession.UserAgent = userAgent;
+                    }
                 }
 
                 if (ShouldTrackPageVisit(context.Request.Path))
@@ -73,6 +80,19 @@ public class VisitorTrackingMiddleware
         }
 
         await _next(context);
+    }
+
+    private static string? ResolveUserAgent(HttpContext context)
+    {
+        var userAgent = context.Request.Headers.UserAgent.ToString();
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return null;
+        }
+
+        return userAgent.Length <= 1024
+            ? userAgent
+            : userAgent[..1024];
     }
 
     private static bool ShouldTrackPageVisit(PathString path)

--- a/CloudCityCenter/Migrations/20260505130000_AddVisitorSessionUserAgent.cs
+++ b/CloudCityCenter/Migrations/20260505130000_AddVisitorSessionUserAgent.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CloudCityCenter.Migrations
+{
+    public partial class AddVisitorSessionUserAgent : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UserAgent",
+                table: "VisitorSessions",
+                type: "TEXT",
+                maxLength: 1024,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UserAgent",
+                table: "VisitorSessions");
+        }
+    }
+}

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -105,6 +105,10 @@ namespace CloudCityCenter.Migrations
                     b.Property<DateTime>("LastSeenAt")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("UserAgent")
+                        .HasMaxLength(1024)
+                        .HasColumnType("TEXT");
+
                     b.HasKey("Id");
 
                     b.ToTable("VisitorSessions");

--- a/CloudCityCenter/Models/Admin/AnalyticsDetailsViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsDetailsViewModel.cs
@@ -6,5 +6,6 @@ public sealed class AnalyticsDetailsViewModel
     public string IpAddress { get; init; } = string.Empty;
     public DateTime FirstSeenAt { get; init; }
     public DateTime LastSeenAt { get; init; }
+    public string? UserAgent { get; init; }
     public IReadOnlyList<PageVisitTimelineItemViewModel> Visits { get; init; } = Array.Empty<PageVisitTimelineItemViewModel>();
 }

--- a/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
@@ -7,4 +7,5 @@ public sealed class VisitorSessionListItemViewModel
     public DateTime FirstSeenAt { get; init; }
     public DateTime LastSeenAt { get; init; }
     public int PagesCount { get; init; }
+    public string? UserAgent { get; init; }
 }

--- a/CloudCityCenter/Models/VisitorSession.cs
+++ b/CloudCityCenter/Models/VisitorSession.cs
@@ -16,5 +16,8 @@ public class VisitorSession
     [Required]
     public DateTime LastSeenAt { get; set; }
 
+    [StringLength(1024)]
+    public string? UserAgent { get; set; }
+
     public ICollection<PageVisit> PageVisits { get; set; } = new List<PageVisit>();
 }


### PR DESCRIPTION
### Motivation
- Admins need visibility into visitors' browser/device information, so the app should capture User-Agent and surface it in analytics without breaking existing session records.

### Description
- Add a nullable `UserAgent` property (max length 1024) to `VisitorSession` and update the EF model snapshot and migration file to add the `UserAgent` column.
- Capture the request User-Agent in `VisitorTrackingMiddleware`, truncate to 1024 characters, set it for new sessions, and update existing sessions only when a non-empty User-Agent is present.
- Extend admin view models (`VisitorSessionListItemViewModel`, `AnalyticsDetailsViewModel`) and `AnalyticsController` projections to include `UserAgent`.
- Update the Analytics UI to show a short preview of the User-Agent in the index (with full value in a tooltip) and the full User-Agent on the details page with a null-safe fallback.

### Testing
- Attempted to generate EF migration with `dotnet ef migrations add AddVisitorSessionUserAgent` but the command failed because the `dotnet` CLI is not available in this environment.
- Created `CloudCityCenter/Migrations/20260505130000_AddVisitorSessionUserAgent.cs` and updated the model snapshot to reflect the new `UserAgent` column via scripted edits.
- Verified the modified files are present and the repository working tree contains the intended changes (no further edits pending).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f2dbfcec832bb569519e24ba6692)