### PR TITLE
Track and display visitor referrer in Analytics Details

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -126,6 +126,7 @@ public class AnalyticsController : Controller
                 FirstSeenAt = x.FirstSeenAt,
                 LastSeenAt = x.LastSeenAt,
                 UserAgent = x.UserAgent,
+                Referrer = x.Referrer,
                 Visits = x.PageVisits
                     .OrderByDescending(p => p.VisitedAt)
                     .Select(p => new PageVisitTimelineItemViewModel

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Details.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Details.cshtml
@@ -26,6 +26,8 @@
             <dd class="col-sm-9">@Model.Visits.Count</dd>
             <dt class="col-sm-3">User-Agent</dt>
             <dd class="col-sm-9"><code class="text-wrap">@(string.IsNullOrWhiteSpace(Model.UserAgent) ? "—" : Model.UserAgent)</code></dd>
+            <dt class="col-sm-3">Referrer</dt>
+            <dd class="col-sm-9"><code class="text-wrap">@(string.IsNullOrWhiteSpace(Model.Referrer) ? "—" : Model.Referrer)</code></dd>
         </dl>
     </div>
 </div>

--- a/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
+++ b/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
@@ -29,6 +29,7 @@ public class VisitorTrackingMiddleware
         {
             var nowUtc = DateTime.UtcNow;
             var userAgent = ResolveUserAgent(context);
+            var referrer = ResolveReferrer(context);
 
             try
             {
@@ -42,7 +43,8 @@ public class VisitorTrackingMiddleware
                         IpAddress = normalizedIp,
                         FirstSeenAt = nowUtc,
                         LastSeenAt = nowUtc,
-                        UserAgent = userAgent
+                        UserAgent = userAgent,
+                        Referrer = referrer
                     };
                     dbContext.VisitorSessions.Add(existingSession);
                 }
@@ -53,6 +55,11 @@ public class VisitorTrackingMiddleware
                     if (!string.IsNullOrWhiteSpace(userAgent))
                     {
                         existingSession.UserAgent = userAgent;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(referrer))
+                    {
+                        existingSession.Referrer = referrer;
                     }
                 }
 
@@ -93,6 +100,20 @@ public class VisitorTrackingMiddleware
         return userAgent.Length <= 1024
             ? userAgent
             : userAgent[..1024];
+    }
+
+
+    private static string? ResolveReferrer(HttpContext context)
+    {
+        var referrer = context.Request.Headers["Referer"].ToString();
+        if (string.IsNullOrWhiteSpace(referrer))
+        {
+            return null;
+        }
+
+        return referrer.Length <= 2048
+            ? referrer
+            : referrer[..2048];
     }
 
     private static bool ShouldTrackPageVisit(PathString path)

--- a/CloudCityCenter/Migrations/20260505140000_AddVisitorSessionReferrer.cs
+++ b/CloudCityCenter/Migrations/20260505140000_AddVisitorSessionReferrer.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CloudCityCenter.Migrations
+{
+    public partial class AddVisitorSessionReferrer : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Referrer",
+                table: "VisitorSessions",
+                type: "TEXT",
+                maxLength: 2048,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Referrer",
+                table: "VisitorSessions");
+        }
+    }
+}

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -105,6 +105,10 @@ namespace CloudCityCenter.Migrations
                     b.Property<DateTime>("LastSeenAt")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("Referrer")
+                        .HasMaxLength(2048)
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("UserAgent")
                         .HasMaxLength(1024)
                         .HasColumnType("TEXT");

--- a/CloudCityCenter/Models/Admin/AnalyticsDetailsViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsDetailsViewModel.cs
@@ -7,5 +7,6 @@ public sealed class AnalyticsDetailsViewModel
     public DateTime FirstSeenAt { get; init; }
     public DateTime LastSeenAt { get; init; }
     public string? UserAgent { get; init; }
+    public string? Referrer { get; init; }
     public IReadOnlyList<PageVisitTimelineItemViewModel> Visits { get; init; } = Array.Empty<PageVisitTimelineItemViewModel>();
 }

--- a/CloudCityCenter/Models/VisitorSession.cs
+++ b/CloudCityCenter/Models/VisitorSession.cs
@@ -19,5 +19,8 @@ public class VisitorSession
     [StringLength(1024)]
     public string? UserAgent { get; set; }
 
+    [StringLength(2048)]
+    public string? Referrer { get; set; }
+
     public ICollection<PageVisit> PageVisits { get; set; } = new List<PageVisit>();
 }


### PR DESCRIPTION
### Motivation
- Capture the incoming `Referer` header for visitor sessions so admins can see where visitors originated. 
- Persist referrer information on the `VisitorSession` entity without truncation beyond a safe limit. 
- Surface the referrer on the Admin Analytics details page while displaying a safe placeholder when none is present.

### Description
- Add a nullable `Referrer` property to `VisitorSession` with `[StringLength(2048)]` to store inbound referrer URLs. 
- Read `Request.Headers["Referer"]` in `VisitorTrackingMiddleware`, trim to 2048 characters via `ResolveReferrer`, and set it when creating or updating a `VisitorSession`. 
- Extend `AnalyticsDetailsViewModel` and the `AnalyticsController.Details` projection to include `Referrer`. 
- Render `Referrer` on the Admin Analytics Details view with a safe fallback of `—` when the value is empty or null and add an EF migration and snapshot update to add the nullable `Referrer` column.

### Testing
- Attempted to run `dotnet ef migrations add AddVisitorSessionReferrer` to generate the migration automatically, but it failed due to `dotnet` not being available in the environment. 
- No automated unit or integration tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f5077790832bbd10b8b7a642bc40)