### PR TITLE
Add Block IP action to Analytics visitor sessions

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using CloudCityCenter.Data;
 using CloudCityCenter.Models.Admin;
+using CloudCityCenter.Models;
+using CloudCityCenter.Services;
 
 namespace CloudCityCenter.Areas.Admin.Controllers;
 
@@ -74,12 +76,41 @@ public class AnalyticsController : Controller
             {
                 Id = x.Id,
                 IpAddress = x.IpAddress,
+                NormalizedIpAddress = ClientIpResolver.TryNormalizeIp(x.IpAddress, out var normalizedIp) ? normalizedIp : string.Empty,
                 FirstSeenAt = x.FirstSeenAt,
                 LastSeenAt = x.LastSeenAt,
                 PagesCount = x.PageVisits.Count,
                 UserAgent = x.UserAgent
             })
             .ToListAsync();
+
+        var normalizedIps = visitors
+            .Select(x => x.NormalizedIpAddress)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var blockedIpSet = normalizedIps.Count == 0
+            ? new HashSet<string>(StringComparer.Ordinal)
+            : await _context.BlockedIps
+                .AsNoTracking()
+                .Where(x => x.IsActive && normalizedIps.Contains(x.IpAddress))
+                .Select(x => x.IpAddress)
+                .ToHashSetAsync(StringComparer.Ordinal);
+
+        visitors = visitors
+            .Select(x => new VisitorSessionListItemViewModel
+            {
+                Id = x.Id,
+                IpAddress = x.IpAddress,
+                NormalizedIpAddress = x.NormalizedIpAddress,
+                FirstSeenAt = x.FirstSeenAt,
+                LastSeenAt = x.LastSeenAt,
+                PagesCount = x.PagesCount,
+                UserAgent = x.UserAgent,
+                IsIpBlocked = !string.IsNullOrWhiteSpace(x.NormalizedIpAddress) && blockedIpSet.Contains(x.NormalizedIpAddress)
+            })
+            .ToList();
 
         var topPages = await _context.PageVisits
             .AsNoTracking()
@@ -146,5 +177,58 @@ public class AnalyticsController : Controller
         }
 
         return View(session);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> BlockIp(int visitorSessionId, string? range = "today", DateTime? startDate = null, DateTime? endDate = null, string? ipAddress = null)
+    {
+        var session = await _context.VisitorSessions
+            .AsNoTracking()
+            .Where(x => x.Id == visitorSessionId)
+            .Select(x => new { x.IpAddress })
+            .FirstOrDefaultAsync();
+
+        if (session is null || !ClientIpResolver.TryNormalizeIp(session.IpAddress, out var normalizedIp))
+        {
+            TempData["ErrorMessage"] = "Could not resolve IP address from this visitor session.";
+            return RedirectToAction(nameof(Index), new { range, startDate, endDate, ipAddress });
+        }
+
+        var currentAdminIp = ClientIpResolver.ResolveNormalizedIp(HttpContext);
+        var confirmSelfBlock = string.Equals(Request.Form["confirmSelfBlock"], "true", StringComparison.OrdinalIgnoreCase);
+        if (string.Equals(currentAdminIp, normalizedIp, StringComparison.Ordinal) && !confirmSelfBlock)
+        {
+            TempData["ErrorMessage"] = "You are trying to block your current admin IP. Submit again with confirmation.";
+            return RedirectToAction(nameof(Index), new { range, startDate, endDate, ipAddress });
+        }
+
+        var existingEntry = await _context.BlockedIps.FirstOrDefaultAsync(x => x.IpAddress == normalizedIp);
+        if (existingEntry?.IsActive == true)
+        {
+            TempData["InfoMessage"] = "Already blocked";
+            return RedirectToAction(nameof(Index), new { range, startDate, endDate, ipAddress });
+        }
+
+        if (existingEntry is null)
+        {
+            _context.BlockedIps.Add(new BlockedIp
+            {
+                IpAddress = normalizedIp,
+                Reason = "Blocked from Analytics",
+                CreatedAt = DateTime.UtcNow,
+                IsActive = true
+            });
+        }
+        else
+        {
+            existingEntry.IsActive = true;
+            existingEntry.CreatedAt = DateTime.UtcNow;
+            existingEntry.Reason = string.IsNullOrWhiteSpace(existingEntry.Reason) ? "Blocked from Analytics" : existingEntry.Reason;
+        }
+
+        await _context.SaveChangesAsync();
+        TempData["SuccessMessage"] = "IP address blocked successfully";
+        return RedirectToAction(nameof(Index), new { range, startDate, endDate, ipAddress });
     }
 }

--- a/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs
@@ -1,7 +1,7 @@
-using System.Net;
 using CloudCityCenter.Data;
 using CloudCityCenter.Models;
 using CloudCityCenter.Models.Admin;
+using CloudCityCenter.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -91,7 +91,7 @@ public class BlockedIpsController : Controller
             return View(model);
         }
 
-        if (!TryNormalizeIp(model.IpAddress, out var normalizedIp))
+        if (!ClientIpResolver.TryNormalizeIp(model.IpAddress, out var normalizedIp))
         {
             ModelState.AddModelError(nameof(model.IpAddress), "Please enter a valid IPv4 or IPv6 address.");
             if (returnToIndex)
@@ -204,36 +204,6 @@ public class BlockedIpsController : Controller
 
         TempData["SuccessMessage"] = "IP address removed from block list";
         return RedirectToAction(nameof(Index));
-    }
-
-    private static bool TryNormalizeIp(string? rawIp, out string normalizedIp)
-    {
-        normalizedIp = string.Empty;
-        if (string.IsNullOrWhiteSpace(rawIp))
-        {
-            return false;
-        }
-
-        return IPAddress.TryParse(rawIp.Trim(), out var parsedIp) &&
-               TryNormalizeIp(parsedIp, out normalizedIp);
-    }
-
-
-    private static bool TryNormalizeIp(IPAddress? ipAddress, out string normalizedIp)
-    {
-        normalizedIp = string.Empty;
-        if (ipAddress == null)
-        {
-            return false;
-        }
-
-        if (ipAddress.IsIPv4MappedToIPv6)
-        {
-            ipAddress = ipAddress.MapToIPv4();
-        }
-
-        normalizedIp = ipAddress.ToString();
-        return true;
     }
 
     private static bool IsBlockedIpDataUnavailable(Exception exception) =>

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -34,6 +34,10 @@
             <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mb-3">
                 <h1 class="h3 mb-0">Analytics Dashboard</h1>
             </div>
+            @if (TempData["InfoMessage"] is string infoMessage && !string.IsNullOrWhiteSpace(infoMessage))
+            {
+                <div class="alert alert-info mb-3">@infoMessage</div>
+            }
 
             <form method="get" class="card card-body mb-3">
                 <div class="row g-2 align-items-end">
@@ -170,6 +174,23 @@
                                             <td><span title="@visitor.UserAgent">@FormatShortUserAgent(visitor.UserAgent)</span></td>
                                             <td class="text-end">
                                                 <a href="@Url.Action("Details", "Analytics", new { area = "Admin", id = visitor.Id })" class="btn btn-sm btn-primary">Details</a>
+                                                @if (visitor.IsIpBlocked)
+                                                {
+                                                    <span class="badge bg-secondary ms-2">Already blocked</span>
+                                                }
+                                                else
+                                                {
+                                                    <form asp-area="Admin" asp-controller="Analytics" asp-action="BlockIp" method="post" class="d-inline ms-2 js-block-ip-form" data-is-current-admin-ip="@(CloudCityCenter.Services.ClientIpResolver.ResolveNormalizedIp(Context) == visitor.NormalizedIpAddress)">
+                                                        @Html.AntiForgeryToken()
+                                                        <input type="hidden" name="visitorSessionId" value="@visitor.Id" />
+                                                        <input type="hidden" name="range" value="@Model.SelectedFilter" />
+                                                        <input type="hidden" name="startDate" value="@Model.StartDateUtc?.ToString("yyyy-MM-dd")" />
+                                                        <input type="hidden" name="endDate" value="@Model.EndDateUtc?.ToString("yyyy-MM-dd")" />
+                                                        <input type="hidden" name="ipAddress" value="@Model.SearchIpAddress" />
+                                                        <input type="hidden" name="confirmSelfBlock" value="false" />
+                                                        <button type="submit" class="btn btn-sm btn-outline-danger">Block IP</button>
+                                                    </form>
+                                                }
                                             </td>
                                         </tr>
                                     }
@@ -182,3 +203,18 @@
         </div>
     </div>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.js-block-ip-form').forEach(function (form) {
+        form.addEventListener('submit', function (event) {
+            if (form.getAttribute('data-is-current-admin-ip') !== 'True') return;
+            if (!window.confirm('This appears to be your current admin IP. Blocking it can lock you out. Continue?')) {
+                event.preventDefault();
+                return;
+            }
+            form.querySelector('input[name="confirmSelfBlock"]').value = 'true';
+        });
+    });
+});
+</script>

--- a/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
@@ -4,8 +4,10 @@ public sealed class VisitorSessionListItemViewModel
 {
     public int Id { get; init; }
     public string IpAddress { get; init; } = string.Empty;
+    public string NormalizedIpAddress { get; init; } = string.Empty;
     public DateTime FirstSeenAt { get; init; }
     public DateTime LastSeenAt { get; init; }
     public int PagesCount { get; init; }
     public string? UserAgent { get; init; }
+    public bool IsIpBlocked { get; init; }
 }


### PR DESCRIPTION
### Motivation
- Allow admins to block suspicious visitor IPs directly from the Analytics UI to speed up mitigation. 
- Reuse existing IP normalization logic so blocking behavior matches the existing `BlockedIps` flows. 
- Prevent accidental self-lockout by requiring explicit confirmation when the admin attempts to block their current admin IP.

### Description
- Added `NormalizedIpAddress` and `IsIpBlocked` to `VisitorSessionListItemViewModel` to carry normalization and blocked-state to the view (`CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs`).
- Extended `AnalyticsController` to compute per-session normalized IPs, load active `BlockedIps` for displayed sessions, mark each visitor row with blocked-state, and added `POST /Admin/Analytics/BlockIp` which creates or re-activates `BlockedIps` entries and returns a friendly message when already blocked (`CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs`).
- Updated Analytics view to show a `Block IP` button per visitor, display an “Already blocked” badge for blocked IPs, and run a client-side confirmation dialog when the IP matches the current admin IP; the server also requires a `confirmSelfBlock` flag (`CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml`).
- Aligned `BlockedIpsController` to reuse the shared normalization logic by switching to `ClientIpResolver.TryNormalizeIp` instead of local parsing helpers (`CloudCityCenter/Areas/Admin/Controllers/BlockedIpsController.cs`).

### Testing
- Attempted to run `dotnet build CloudCityCenter/CloudCityCenter.csproj`, but the `dotnet` tool is not available in this environment so the build could not be executed here (no automated tests ran in CI in this session).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f647545c832b98ddbe19f1aea78e)