### PR TITLE
AnalyticsController: Materialize EF queries and replace ToHashSetAsync

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -70,19 +70,35 @@ public class AnalyticsController : Controller
                 .Where(x => x.IpAddress.Contains(searchIpAddress));
         }
 
-        var visitors = await visitorSessionsQuery
+        var visitorSessionRows = await visitorSessionsQuery
             .OrderByDescending(x => x.LastSeenAt)
-            .Select(x => new VisitorSessionListItemViewModel
+            .Select(x => new
             {
-                Id = x.Id,
-                IpAddress = x.IpAddress,
-                NormalizedIpAddress = ClientIpResolver.TryNormalizeIp(x.IpAddress, out var normalizedIp) ? normalizedIp : string.Empty,
-                FirstSeenAt = x.FirstSeenAt,
-                LastSeenAt = x.LastSeenAt,
+                x.Id,
+                x.IpAddress,
+                x.FirstSeenAt,
+                x.LastSeenAt,
                 PagesCount = x.PageVisits.Count,
-                UserAgent = x.UserAgent
+                x.UserAgent
             })
             .ToListAsync();
+
+        var visitors = visitorSessionRows
+            .Select(x =>
+            {
+                var hasNormalizedIp = ClientIpResolver.TryNormalizeIp(x.IpAddress, out var normalizedIp);
+                return new VisitorSessionListItemViewModel
+                {
+                    Id = x.Id,
+                    IpAddress = x.IpAddress,
+                    NormalizedIpAddress = hasNormalizedIp ? normalizedIp : string.Empty,
+                    FirstSeenAt = x.FirstSeenAt,
+                    LastSeenAt = x.LastSeenAt,
+                    PagesCount = x.PagesCount,
+                    UserAgent = x.UserAgent
+                };
+            })
+            .ToList();
 
         var normalizedIps = visitors
             .Select(x => x.NormalizedIpAddress)
@@ -90,13 +106,17 @@ public class AnalyticsController : Controller
             .Distinct(StringComparer.Ordinal)
             .ToList();
 
-        var blockedIpSet = normalizedIps.Count == 0
-            ? new HashSet<string>(StringComparer.Ordinal)
-            : await _context.BlockedIps
+        var blockedIpSet = new HashSet<string>(StringComparer.Ordinal);
+        if (normalizedIps.Count != 0)
+        {
+            var blockedIpList = await _context.BlockedIps
                 .AsNoTracking()
                 .Where(x => x.IsActive && normalizedIps.Contains(x.IpAddress))
                 .Select(x => x.IpAddress)
-                .ToHashSetAsync(StringComparer.Ordinal);
+                .ToListAsync();
+
+            blockedIpSet = blockedIpList.ToHashSet(StringComparer.Ordinal);
+        }
 
         visitors = visitors
             .Select(x => new VisitorSessionListItemViewModel


### PR DESCRIPTION
### Motivation
- Fix build errors caused by using `ToHashSetAsync` on an EF projection and by declaring `out` variables inside LINQ-to-Entities expression trees.
- Ensure IP normalization and parsing run in memory after materializing DB rows so EF expression trees are not required to handle local C# logic.

### Description
- Replaced the direct EF projection to `VisitorSessionListItemViewModel` with an anonymous projection materialized via `ToListAsync()` and then mapped to `VisitorSessionListItemViewModel` in memory using `ClientIpResolver.TryNormalizeIp(..., out var normalizedIp)`.
- Replaced `ToHashSetAsync(StringComparer.Ordinal)` with a two-step pattern: `ToListAsync()` followed by `.ToHashSet(StringComparer.Ordinal)` and initialize `blockedIpSet` defensively when there are no normalized IPs.
- Kept existing behavior for top pages, page visit counts, and view model population intact; changes are limited to `CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs`.

### Testing
- Attempted to run `dotnet build` in the `CloudCityCenter` project, but the command failed in this environment because the .NET SDK is not installed (`bash: command not found: dotnet`).
- `dotnet publish` was not executed for the same environment limitation, so build/publish could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f85a939c832ba409b05fa2ed538e)