### PR TITLE
Add Online Users block to Admin Analytics

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -153,6 +153,39 @@ public class AnalyticsController : Controller
             .Where(x => x.VisitedAt >= filterStart && x.VisitedAt < filterEndExclusive)
             .CountAsync();
 
+        var onlineThresholdUtc = DateTime.UtcNow.AddMinutes(-5);
+        var activeVisitorRows = await _context.VisitorSessions
+            .AsNoTracking()
+            .Where(x => x.LastSeenAt >= onlineThresholdUtc)
+            .OrderByDescending(x => x.LastSeenAt)
+            .Select(x => new
+            {
+                x.Id,
+                x.IpAddress,
+                x.FirstSeenAt,
+                x.LastSeenAt,
+                PagesCount = x.PageVisits.Count,
+                x.UserAgent
+            })
+            .ToListAsync();
+
+        var activeVisitors = activeVisitorRows
+            .Select(x =>
+            {
+                var hasNormalizedIp = ClientIpResolver.TryNormalizeIp(x.IpAddress, out var normalizedIp);
+                return new VisitorSessionListItemViewModel
+                {
+                    Id = x.Id,
+                    IpAddress = x.IpAddress,
+                    NormalizedIpAddress = hasNormalizedIp ? normalizedIp : string.Empty,
+                    FirstSeenAt = x.FirstSeenAt,
+                    LastSeenAt = x.LastSeenAt,
+                    PagesCount = x.PagesCount,
+                    UserAgent = x.UserAgent
+                };
+            })
+            .ToList();
+
         return View(new AnalyticsIndexViewModel
         {
             SelectedFilter = selectedRange,
@@ -160,6 +193,8 @@ public class AnalyticsController : Controller
             StartDateUtc = filterStart,
             EndDateUtc = filterEndExclusive.AddTicks(-1),
             TotalPageVisits = totalPageVisits,
+            OnlineNowCount = activeVisitors.Count,
+            ActiveVisitors = activeVisitors,
             Visitors = visitors,
             TopPages = topPages
         });

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -87,7 +87,15 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-12 col-lg-4">
+                <div class="col-12 col-sm-6 col-lg-3">
+                    <div class="card h-100 border-0 shadow-sm">
+                        <div class="card-body">
+                            <h6 class="text-muted mb-2">Online now</h6>
+                            <p class="display-6 mb-0">@Model.OnlineNowCount</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-sm-6 col-lg-3">
                     <div class="card h-100 border-0 shadow-sm">
                         <div class="card-body">
                             <h6 class="text-muted mb-2">Total page visits</h6>
@@ -98,6 +106,40 @@
             </div>
 
             <p class="text-muted small">Filter window (UTC): @Model.StartDateUtc?.ToString("yyyy-MM-dd HH:mm:ss") to @Model.EndDateUtc?.ToString("yyyy-MM-dd HH:mm:ss")</p>
+
+            <div class="card mb-3">
+                <div class="card-body">
+                    <h5 class="card-title">Active Visitors (Last 5 Minutes)</h5>
+                    @if (Model.ActiveVisitors.Count == 0)
+                    {
+                        <div class="alert alert-info mb-0">No active visitors in the last 5 minutes.</div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover table-bordered align-middle mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>IP</th>
+                                        <th>Last seen (UTC)</th>
+                                        <th>Pages count</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var visitor in Model.ActiveVisitors)
+                                    {
+                                        <tr>
+                                            <td><code>@visitor.IpAddress</code></td>
+                                            <td>@visitor.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                                            <td>@visitor.PagesCount</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+            </div>
 
             <div class="card mb-3">
                 <div class="card-body">

--- a/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
@@ -7,6 +7,8 @@ public sealed class AnalyticsIndexViewModel
     public DateTime? StartDateUtc { get; init; }
     public DateTime? EndDateUtc { get; init; }
     public int TotalPageVisits { get; init; }
+    public int OnlineNowCount { get; init; }
+    public IReadOnlyList<VisitorSessionListItemViewModel> ActiveVisitors { get; init; } = Array.Empty<VisitorSessionListItemViewModel>();
     public IReadOnlyList<VisitorSessionListItemViewModel> Visitors { get; init; } = Array.Empty<VisitorSessionListItemViewModel>();
     public IReadOnlyList<TopPageVisitViewModel> TopPages { get; init; } = Array.Empty<TopPageVisitViewModel>();
 }


### PR DESCRIPTION
### Motivation
- Display real-time active visitors on the Admin Analytics dashboard using existing session data.
- Consider a visitor "online" when `VisitorSessions.LastSeenAt >= DateTime.UtcNow.AddMinutes(-5)`.
- Do not alter the database schema or existing analytics behavior.

### Description
- Added `OnlineNowCount` and `ActiveVisitors` to `AnalyticsIndexViewModel` to carry the new data to the UI.
- Queried active sessions in `AnalyticsController` with `LastSeenAt >= DateTime.UtcNow.AddMinutes(-5)` and mapped `PagesCount` from `PageVisits.Count` into `VisitorSessionListItemViewModel` instances.
- Populated the returned `AnalyticsIndexViewModel` with `OnlineNowCount` and `ActiveVisitors` alongside existing data.
- Updated `Areas/Admin/Views/Analytics/Index.cshtml` to include a summary card `Online now` and an `Active Visitors (Last 5 Minutes)` table with columns `IP`, `Last seen (UTC)`, and `Pages count`.

### Testing
- Attempted `dotnet build CloudCityCenter.sln`, which failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- Verified changes were staged and committed locally with `git` (commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fef9dd60832bbc24fa7caef11422)