### PR TITLE
Add browser and device analytics to admin dashboard

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -87,6 +87,8 @@ public class AnalyticsController : Controller
             .Select(x =>
             {
                 var hasNormalizedIp = ClientIpResolver.TryNormalizeIp(x.IpAddress, out var normalizedIp);
+                var browser = DetectBrowser(x.UserAgent);
+                var device = DetectDevice(x.UserAgent);
                 return new VisitorSessionListItemViewModel
                 {
                     Id = x.Id,
@@ -95,9 +97,25 @@ public class AnalyticsController : Controller
                     FirstSeenAt = x.FirstSeenAt,
                     LastSeenAt = x.LastSeenAt,
                     PagesCount = x.PagesCount,
-                    UserAgent = x.UserAgent
+                    UserAgent = x.UserAgent,
+                    Browser = browser,
+                    Device = device
                 };
             })
+            .ToList();
+
+        var topBrowsers = visitors
+            .GroupBy(v => v.Browser)
+            .Select(g => new AnalyticsBreakdownItemViewModel { Label = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Label)
+            .ToList();
+
+        var deviceSplit = visitors
+            .GroupBy(v => v.Device)
+            .Select(g => new AnalyticsBreakdownItemViewModel { Label = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Label)
             .ToList();
 
         var normalizedIps = visitors
@@ -128,6 +146,8 @@ public class AnalyticsController : Controller
                 LastSeenAt = x.LastSeenAt,
                 PagesCount = x.PagesCount,
                 UserAgent = x.UserAgent,
+                Browser = x.Browser,
+                Device = x.Device,
                 IsIpBlocked = !string.IsNullOrWhiteSpace(x.NormalizedIpAddress) && blockedIpSet.Contains(x.NormalizedIpAddress)
             })
             .ToList();
@@ -181,7 +201,9 @@ public class AnalyticsController : Controller
                     FirstSeenAt = x.FirstSeenAt,
                     LastSeenAt = x.LastSeenAt,
                     PagesCount = x.PagesCount,
-                    UserAgent = x.UserAgent
+                    UserAgent = x.UserAgent,
+                    Browser = DetectBrowser(x.UserAgent),
+                    Device = DetectDevice(x.UserAgent)
                 };
             })
             .ToList();
@@ -196,8 +218,47 @@ public class AnalyticsController : Controller
             OnlineNowCount = activeVisitors.Count,
             ActiveVisitors = activeVisitors,
             Visitors = visitors,
-            TopPages = topPages
+            TopPages = topPages,
+            TopBrowsers = topBrowsers,
+            DeviceSplit = deviceSplit
         });
+    }
+
+    private static string DetectBrowser(string? userAgent)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return "Other";
+        }
+
+        if (userAgent.Contains("Edg/", StringComparison.OrdinalIgnoreCase)) return "Edge";
+        if (userAgent.Contains("Firefox/", StringComparison.OrdinalIgnoreCase)) return "Firefox";
+        if (userAgent.Contains("Chrome/", StringComparison.OrdinalIgnoreCase) &&
+            !userAgent.Contains("Chromium", StringComparison.OrdinalIgnoreCase)) return "Chrome";
+        if (userAgent.Contains("Safari/", StringComparison.OrdinalIgnoreCase) &&
+            !userAgent.Contains("Chrome/", StringComparison.OrdinalIgnoreCase) &&
+            !userAgent.Contains("Chromium", StringComparison.OrdinalIgnoreCase)) return "Safari";
+
+        return "Other";
+    }
+
+    private static string DetectDevice(string? userAgent)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            return "Desktop";
+        }
+
+        if (userAgent.Contains("bot", StringComparison.OrdinalIgnoreCase) ||
+            userAgent.Contains("spider", StringComparison.OrdinalIgnoreCase) ||
+            userAgent.Contains("crawl", StringComparison.OrdinalIgnoreCase)) return "Bot";
+        if (userAgent.Contains("iPad", StringComparison.OrdinalIgnoreCase) ||
+            userAgent.Contains("Tablet", StringComparison.OrdinalIgnoreCase)) return "Tablet";
+        if (userAgent.Contains("Mobi", StringComparison.OrdinalIgnoreCase) ||
+            userAgent.Contains("Android", StringComparison.OrdinalIgnoreCase) ||
+            userAgent.Contains("iPhone", StringComparison.OrdinalIgnoreCase)) return "Mobile";
+
+        return "Desktop";
     }
 
     public async Task<IActionResult> Details(int id)

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -176,6 +176,59 @@
                 </div>
             </div>
 
+            <div class="row g-3 mb-3">
+                <div class="col-12 col-lg-6">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Top Browsers</h5>
+                            @if (Model.TopBrowsers.Count == 0)
+                            {
+                                <div class="alert alert-info mb-0">No browser data found.</div>
+                            }
+                            else
+                            {
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-striped mb-0">
+                                        <thead><tr><th>Browser</th><th>Sessions</th></tr></thead>
+                                        <tbody>
+                                        @foreach (var item in Model.TopBrowsers)
+                                        {
+                                            <tr><td>@item.Label</td><td>@item.Count</td></tr>
+                                        }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-6">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Devices Split</h5>
+                            @if (Model.DeviceSplit.Count == 0)
+                            {
+                                <div class="alert alert-info mb-0">No device data found.</div>
+                            }
+                            else
+                            {
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-striped mb-0">
+                                        <thead><tr><th>Device</th><th>Sessions</th></tr></thead>
+                                        <tbody>
+                                        @foreach (var item in Model.DeviceSplit)
+                                        {
+                                            <tr><td>@item.Label</td><td>@item.Count</td></tr>
+                                        }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">Visitor Sessions</h5>
@@ -201,6 +254,8 @@
                                         <th>First Seen UTC</th>
                                         <th>Last Seen UTC</th>
                                         <th>Pages Count</th>
+                                        <th>Browser</th>
+                                        <th>Device</th>
                                         <th>User-Agent</th>
                                         <th></th>
                                     </tr>
@@ -213,6 +268,8 @@
                                             <td>@visitor.FirstSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.PagesCount</td>
+                                            <td>@visitor.Browser</td>
+                                            <td>@visitor.Device</td>
                                             <td><span title="@visitor.UserAgent">@FormatShortUserAgent(visitor.UserAgent)</span></td>
                                             <td class="text-end">
                                                 <a href="@Url.Action("Details", "Analytics", new { area = "Admin", id = visitor.Id })" class="btn btn-sm btn-primary">Details</a>

--- a/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
@@ -11,4 +11,12 @@ public sealed class AnalyticsIndexViewModel
     public IReadOnlyList<VisitorSessionListItemViewModel> ActiveVisitors { get; init; } = Array.Empty<VisitorSessionListItemViewModel>();
     public IReadOnlyList<VisitorSessionListItemViewModel> Visitors { get; init; } = Array.Empty<VisitorSessionListItemViewModel>();
     public IReadOnlyList<TopPageVisitViewModel> TopPages { get; init; } = Array.Empty<TopPageVisitViewModel>();
+    public IReadOnlyList<AnalyticsBreakdownItemViewModel> TopBrowsers { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
+    public IReadOnlyList<AnalyticsBreakdownItemViewModel> DeviceSplit { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
+}
+
+public sealed class AnalyticsBreakdownItemViewModel
+{
+    public string Label { get; init; } = string.Empty;
+    public int Count { get; init; }
 }

--- a/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
@@ -9,5 +9,7 @@ public sealed class VisitorSessionListItemViewModel
     public DateTime LastSeenAt { get; init; }
     public int PagesCount { get; init; }
     public string? UserAgent { get; init; }
+    public string Browser { get; init; } = "Other";
+    public string Device { get; init; } = "Desktop";
     public bool IsIpBlocked { get; init; }
 }


### PR DESCRIPTION
### Motivation
- Provide basic browser and device analytics so admins can see which browsers and device types visit the site and summarize them on the analytics dashboard. 
- Reuse the existing `UserAgent` captured on `VisitorSession` to derive lightweight classifications (browser and device) without storing extra DB fields. 
- Ensure older records with null `UserAgent` do not break the analytics UI by using safe defaults.

### Description
- Added `Browser` and `Device` properties to `VisitorSessionListItemViewModel` so per-session classifications are available to views without re-parsing in the Razor template. 
- Extended `AnalyticsIndexViewModel` with `TopBrowsers` and `DeviceSplit` breakdown lists and added a small `AnalyticsBreakdownItemViewModel`. 
- Implemented `DetectBrowser` and `DetectDevice` helper methods in `AnalyticsController` and populated `Browser`/`Device` for both filtered visitors and active visitors, plus computed grouped `TopBrowsers` and `DeviceSplit` collections. 
- Updated the analytics Razor view `Index.cshtml` to add `Browser` and `Device` columns in the Visitor Sessions table and to display summary tables for Top Browsers and Devices Split; `UserAgent` remains shown and shortened for readability.

### Testing
- Attempted to run `dotnet build CloudCityCenter.sln` in this environment, but the command failed because `dotnet` is not installed here (build not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa005642e4832bbf6e1813ad8c2fdf)