### PR TITLE
Add suspicious activity detection and block actions to Admin Analytics

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -21,6 +21,7 @@ public class AnalyticsController : Controller
 
     public async Task<IActionResult> Index(string? range = "today", DateTime? startDate = null, DateTime? endDate = null, string? ipAddress = null)
     {
+        var suspiciousPaths = new[] { "/wp-admin", "/xmlrpc.php", "/.env", "/phpmyadmin" };
         var selectedRange = (range ?? "today").Trim().ToLowerInvariant();
         var searchIpAddress = (ipAddress ?? string.Empty).Trim();
         var utcToday = DateTime.UtcNow.Date;
@@ -83,6 +84,37 @@ public class AnalyticsController : Controller
             })
             .ToListAsync();
 
+        var suspiciousBurstRows = await _context.PageVisits
+            .AsNoTracking()
+            .Where(x => x.VisitedAt >= filterStart && x.VisitedAt < filterEndExclusive)
+            .GroupBy(x => x.VisitorSessionId)
+            .Where(g => g.Count() > 100 && EF.Functions.DateDiffMinute(g.Min(p => p.VisitedAt), g.Max(p => p.VisitedAt)) <= 10)
+            .Select(g => new
+            {
+                VisitorSessionId = g.Key,
+                VisitsCount = g.Count(),
+                FirstVisitAt = g.Min(p => p.VisitedAt),
+                LastVisitAt = g.Max(p => p.VisitedAt)
+            })
+            .ToListAsync();
+
+        var suspiciousPathRows = await _context.PageVisits
+            .AsNoTracking()
+            .Where(x => x.VisitedAt >= filterStart && x.VisitedAt < filterEndExclusive)
+            .Where(x => suspiciousPaths.Contains(x.Path))
+            .Select(x => new
+            {
+                x.VisitorSessionId,
+                x.Path,
+                x.VisitedAt
+            })
+            .ToListAsync();
+
+        var suspiciousVisitorIdSet = suspiciousBurstRows
+            .Select(x => x.VisitorSessionId)
+            .Concat(suspiciousPathRows.Select(x => x.VisitorSessionId))
+            .ToHashSet();
+
         var visitors = visitorSessionRows
             .Select(x =>
             {
@@ -99,7 +131,8 @@ public class AnalyticsController : Controller
                     PagesCount = x.PagesCount,
                     UserAgent = x.UserAgent,
                     Browser = browser,
-                    Device = device
+                    Device = device,
+                    IsSuspicious = suspiciousVisitorIdSet.Contains(x.Id)
                 };
             })
             .ToList();
@@ -148,9 +181,47 @@ public class AnalyticsController : Controller
                 UserAgent = x.UserAgent,
                 Browser = x.Browser,
                 Device = x.Device,
+                IsSuspicious = x.IsSuspicious,
                 IsIpBlocked = !string.IsNullOrWhiteSpace(x.NormalizedIpAddress) && blockedIpSet.Contains(x.NormalizedIpAddress)
             })
             .ToList();
+
+        var visitorById = visitors.ToDictionary(x => x.Id);
+
+        var suspiciousActivities = new List<SuspiciousActivityListItemViewModel>();
+        foreach (var burst in suspiciousBurstRows.OrderByDescending(x => x.LastVisitAt))
+        {
+            if (!visitorById.TryGetValue(burst.VisitorSessionId, out var visitor))
+            {
+                continue;
+            }
+
+            suspiciousActivities.Add(new SuspiciousActivityListItemViewModel
+            {
+                VisitorSessionId = burst.VisitorSessionId,
+                IpAddress = visitor.IpAddress,
+                Reason = $"{burst.VisitsCount} visits within 10 minutes",
+                DetectedAtUtc = burst.LastVisitAt,
+                IsIpBlocked = visitor.IsIpBlocked
+            });
+        }
+
+        foreach (var item in suspiciousPathRows.OrderByDescending(x => x.VisitedAt))
+        {
+            if (!visitorById.TryGetValue(item.VisitorSessionId, out var visitor))
+            {
+                continue;
+            }
+
+            suspiciousActivities.Add(new SuspiciousActivityListItemViewModel
+            {
+                VisitorSessionId = item.VisitorSessionId,
+                IpAddress = visitor.IpAddress,
+                Reason = $"Requested suspicious path {item.Path}",
+                DetectedAtUtc = item.VisitedAt,
+                IsIpBlocked = visitor.IsIpBlocked
+            });
+        }
 
         var topPages = await _context.PageVisits
             .AsNoTracking()
@@ -218,6 +289,7 @@ public class AnalyticsController : Controller
             OnlineNowCount = activeVisitors.Count,
             ActiveVisitors = activeVisitors,
             Visitors = visitors,
+            SuspiciousActivities = suspiciousActivities,
             TopPages = topPages,
             TopBrowsers = topBrowsers,
             DeviceSplit = deviceSplit

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -143,6 +143,52 @@
 
             <div class="card mb-3">
                 <div class="card-body">
+                    <h5 class="card-title">Suspicious Activity</h5>
+                    @if (Model.SuspiciousActivities.Count == 0)
+                    {
+                        <div class="alert alert-success mb-0">No suspicious activity detected in the selected time window.</div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive mb-3">
+                            <table class="table table-striped table-hover table-bordered align-middle mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Detected UTC</th>
+                                        <th>IP</th>
+                                        <th>Reason</th>
+                                        <th></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                @foreach (var activity in Model.SuspiciousActivities)
+                                {
+                                    <tr>
+                                        <td>@activity.DetectedAtUtc.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                                        <td><code>@activity.IpAddress</code></td>
+                                        <td><span class="badge bg-warning text-dark">Suspicious</span> @activity.Reason</td>
+                                        <td class="text-end">
+                                            <a href="@Url.Action("Details", "Analytics", new { area = "Admin", id = activity.VisitorSessionId })" class="btn btn-sm btn-primary">Details</a>
+                                            @if (!activity.IsIpBlocked)
+                                            {
+                                                <form asp-area="Admin" asp-controller="Analytics" asp-action="BlockIp" method="post" class="d-inline ms-2 js-block-ip-form">
+                                                    @Html.AntiForgeryToken()
+                                                    <input type="hidden" name="visitorSessionId" value="@activity.VisitorSessionId" />
+                                                    <button type="submit" class="btn btn-sm btn-outline-danger">Block IP</button>
+                                                </form>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-body">
                     <h5 class="card-title">Top Pages</h5>
 
                     @if (Model.TopPages.Count == 0)
@@ -251,6 +297,7 @@
                                 <thead>
                                     <tr>
                                         <th>IP Address</th>
+                                        <th>Status</th>
                                         <th>First Seen UTC</th>
                                         <th>Last Seen UTC</th>
                                         <th>Pages Count</th>
@@ -265,6 +312,12 @@
                                     {
                                         <tr>
                                             <td><code>@visitor.IpAddress</code></td>
+                                            <td>
+                                                @if (visitor.IsSuspicious)
+                                                {
+                                                    <span class="badge bg-warning text-dark">Suspicious</span>
+                                                }
+                                            </td>
                                             <td>@visitor.FirstSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.PagesCount</td>

--- a/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
@@ -13,10 +13,20 @@ public sealed class AnalyticsIndexViewModel
     public IReadOnlyList<TopPageVisitViewModel> TopPages { get; init; } = Array.Empty<TopPageVisitViewModel>();
     public IReadOnlyList<AnalyticsBreakdownItemViewModel> TopBrowsers { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
     public IReadOnlyList<AnalyticsBreakdownItemViewModel> DeviceSplit { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
+    public IReadOnlyList<SuspiciousActivityListItemViewModel> SuspiciousActivities { get; init; } = Array.Empty<SuspiciousActivityListItemViewModel>();
 }
 
 public sealed class AnalyticsBreakdownItemViewModel
 {
     public string Label { get; init; } = string.Empty;
     public int Count { get; init; }
+}
+
+public sealed class SuspiciousActivityListItemViewModel
+{
+    public int VisitorSessionId { get; init; }
+    public string IpAddress { get; init; } = string.Empty;
+    public string Reason { get; init; } = string.Empty;
+    public DateTime DetectedAtUtc { get; init; }
+    public bool IsIpBlocked { get; init; }
 }

--- a/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
@@ -11,5 +11,6 @@ public sealed class VisitorSessionListItemViewModel
     public string? UserAgent { get; init; }
     public string Browser { get; init; } = "Other";
     public string Device { get; init; } = "Desktop";
+    public bool IsSuspicious { get; init; }
     public bool IsIpBlocked { get; init; }
 }


### PR DESCRIPTION
### Motivation
- Surface visitors that exhibit abusive behaviour (high-frequency page visits or requests to known sensitive paths) so admins can inspect and block them from the Analytics UI.

### Description
- Added burst detection by querying `PageVisits` grouped by `VisitorSessionId` to find sessions with >100 visits within a 10 minute window using `EF.Functions.DateDiffMinute`.
- Added suspicious-path checks for `/wp-admin`, `/xmlrpc.php`, `/.env`, and `/phpmyadmin` and combined results into a suspicious visitor set.
- Extended view models with `IsSuspicious` on `VisitorSessionListItemViewModel` and a new `SuspiciousActivityListItemViewModel` plus `SuspiciousActivities` on `AnalyticsIndexViewModel`.
- Updated the Analytics UI to show a **Suspicious Activity** block (timestamp, IP, reason, details link) and a `Suspicious` badge in the Visitor Sessions table, and reused the existing `BlockIp` action (optional block button) for admin blocking.

### Testing
- Attempted to run `dotnet build CloudCityCenter.sln`, but the `dotnet` CLI is not available in this environment so the build and automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa033f6548832b901db8a78e1a37c3)