### PR TITLE
Add geo fields to visitor analytics and Top Countries block

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -80,7 +80,10 @@ public class AnalyticsController : Controller
                 x.FirstSeenAt,
                 x.LastSeenAt,
                 PagesCount = x.PageVisits.Count,
-                x.UserAgent
+                x.UserAgent,
+                x.Country,
+                x.City,
+                x.CountryCode
             })
             .ToListAsync();
 
@@ -130,6 +133,9 @@ public class AnalyticsController : Controller
                     LastSeenAt = x.LastSeenAt,
                     PagesCount = x.PagesCount,
                     UserAgent = x.UserAgent,
+                    Country = x.Country,
+                    City = x.City,
+                    CountryCode = x.CountryCode,
                     Browser = browser,
                     Device = device,
                     IsSuspicious = suspiciousVisitorIdSet.Contains(x.Id)
@@ -149,6 +155,15 @@ public class AnalyticsController : Controller
             .Select(g => new AnalyticsBreakdownItemViewModel { Label = g.Key, Count = g.Count() })
             .OrderByDescending(x => x.Count)
             .ThenBy(x => x.Label)
+            .ToList();
+
+        var topCountries = visitors
+            .Where(v => !string.IsNullOrWhiteSpace(v.Country))
+            .GroupBy(v => v.Country!.Trim())
+            .Select(g => new AnalyticsBreakdownItemViewModel { Label = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Label)
+            .Take(10)
             .ToList();
 
         var normalizedIps = visitors
@@ -179,6 +194,9 @@ public class AnalyticsController : Controller
                 LastSeenAt = x.LastSeenAt,
                 PagesCount = x.PagesCount,
                 UserAgent = x.UserAgent,
+                Country = x.Country,
+                City = x.City,
+                CountryCode = x.CountryCode,
                 Browser = x.Browser,
                 Device = x.Device,
                 IsSuspicious = x.IsSuspicious,
@@ -256,7 +274,10 @@ public class AnalyticsController : Controller
                 x.FirstSeenAt,
                 x.LastSeenAt,
                 PagesCount = x.PageVisits.Count,
-                x.UserAgent
+                x.UserAgent,
+                x.Country,
+                x.City,
+                x.CountryCode
             })
             .ToListAsync();
 
@@ -273,6 +294,9 @@ public class AnalyticsController : Controller
                     LastSeenAt = x.LastSeenAt,
                     PagesCount = x.PagesCount,
                     UserAgent = x.UserAgent,
+                    Country = x.Country,
+                    City = x.City,
+                    CountryCode = x.CountryCode,
                     Browser = DetectBrowser(x.UserAgent),
                     Device = DetectDevice(x.UserAgent)
                 };
@@ -292,6 +316,7 @@ public class AnalyticsController : Controller
             SuspiciousActivities = suspiciousActivities,
             TopPages = topPages,
             TopBrowsers = topBrowsers,
+            TopCountries = topCountries,
             DeviceSplit = deviceSplit
         });
     }

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -223,7 +223,7 @@
             </div>
 
             <div class="row g-3 mb-3">
-                <div class="col-12 col-lg-6">
+                <div class="col-12 col-lg-4">
                     <div class="card h-100">
                         <div class="card-body">
                             <h5 class="card-title">Top Browsers</h5>
@@ -248,7 +248,32 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-12 col-lg-6">
+                <div class="col-12 col-lg-4">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">Top Countries</h5>
+                            @if (Model.TopCountries.Count == 0)
+                            {
+                                <div class="alert alert-info mb-0">No country data found.</div>
+                            }
+                            else
+                            {
+                                <div class="table-responsive">
+                                    <table class="table table-sm table-striped mb-0">
+                                        <thead><tr><th>Country</th><th>Sessions</th></tr></thead>
+                                        <tbody>
+                                        @foreach (var item in Model.TopCountries)
+                                        {
+                                            <tr><td>@item.Label</td><td>@item.Count</td></tr>
+                                        }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-4">
                     <div class="card h-100">
                         <div class="card-body">
                             <h5 class="card-title">Devices Split</h5>
@@ -301,6 +326,8 @@
                                         <th>First Seen UTC</th>
                                         <th>Last Seen UTC</th>
                                         <th>Pages Count</th>
+                                        <th>Country</th>
+                                        <th>City</th>
                                         <th>Browser</th>
                                         <th>Device</th>
                                         <th>User-Agent</th>
@@ -321,6 +348,8 @@
                                             <td>@visitor.FirstSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.LastSeenAt.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                             <td>@visitor.PagesCount</td>
+                                            <td>@(!string.IsNullOrWhiteSpace(visitor.Country) ? visitor.Country : "—")</td>
+                                            <td>@(!string.IsNullOrWhiteSpace(visitor.City) ? visitor.City : "—")</td>
                                             <td>@visitor.Browser</td>
                                             <td>@visitor.Device</td>
                                             <td><span title="@visitor.UserAgent">@FormatShortUserAgent(visitor.UserAgent)</span></td>

--- a/CloudCityCenter/Migrations/20260505153000_AddVisitorSessionGeoFields.cs
+++ b/CloudCityCenter/Migrations/20260505153000_AddVisitorSessionGeoFields.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CloudCityCenter.Migrations
+{
+    public partial class AddVisitorSessionGeoFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "City",
+                table: "VisitorSessions",
+                type: "TEXT",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Country",
+                table: "VisitorSessions",
+                type: "TEXT",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CountryCode",
+                table: "VisitorSessions",
+                type: "TEXT",
+                maxLength: 2,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "City",
+                table: "VisitorSessions");
+
+            migrationBuilder.DropColumn(
+                name: "Country",
+                table: "VisitorSessions");
+
+            migrationBuilder.DropColumn(
+                name: "CountryCode",
+                table: "VisitorSessions");
+        }
+    }
+}

--- a/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CloudCityCenter/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -97,6 +97,18 @@ namespace CloudCityCenter.Migrations
                     b.Property<DateTime>("FirstSeenAt")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("City")
+                        .HasMaxLength(128)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Country")
+                        .HasMaxLength(128)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("CountryCode")
+                        .HasMaxLength(2)
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("IpAddress")
                         .IsRequired()
                         .HasMaxLength(45)

--- a/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
@@ -12,6 +12,7 @@ public sealed class AnalyticsIndexViewModel
     public IReadOnlyList<VisitorSessionListItemViewModel> Visitors { get; init; } = Array.Empty<VisitorSessionListItemViewModel>();
     public IReadOnlyList<TopPageVisitViewModel> TopPages { get; init; } = Array.Empty<TopPageVisitViewModel>();
     public IReadOnlyList<AnalyticsBreakdownItemViewModel> TopBrowsers { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
+    public IReadOnlyList<AnalyticsBreakdownItemViewModel> TopCountries { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
     public IReadOnlyList<AnalyticsBreakdownItemViewModel> DeviceSplit { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
     public IReadOnlyList<SuspiciousActivityListItemViewModel> SuspiciousActivities { get; init; } = Array.Empty<SuspiciousActivityListItemViewModel>();
 }

--- a/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
+++ b/CloudCityCenter/Models/Admin/VisitorSessionListItemViewModel.cs
@@ -9,6 +9,9 @@ public sealed class VisitorSessionListItemViewModel
     public DateTime LastSeenAt { get; init; }
     public int PagesCount { get; init; }
     public string? UserAgent { get; init; }
+    public string? Country { get; init; }
+    public string? City { get; init; }
+    public string? CountryCode { get; init; }
     public string Browser { get; init; } = "Other";
     public string Device { get; init; } = "Desktop";
     public bool IsSuspicious { get; init; }

--- a/CloudCityCenter/Models/VisitorSession.cs
+++ b/CloudCityCenter/Models/VisitorSession.cs
@@ -22,5 +22,14 @@ public class VisitorSession
     [StringLength(2048)]
     public string? Referrer { get; set; }
 
+    [StringLength(128)]
+    public string? Country { get; set; }
+
+    [StringLength(128)]
+    public string? City { get; set; }
+
+    [StringLength(2)]
+    public string? CountryCode { get; set; }
+
     public ICollection<PageVisit> PageVisits { get; set; } = new List<PageVisit>();
 }


### PR DESCRIPTION
### Motivation
- Add optional geolocation metadata to visitor sessions so analytics can display country/city information when a geo lookup is available, while remaining safe when not configured. 
- Surface country/city in the admin Analytics UI and provide a Top Countries breakdown without introducing any paid geo API calls. 

### Description
- Added nullable `Country`, `City`, and `CountryCode` properties to the `VisitorSession` model with length annotations. 
- Created EF migration `AddVisitorSessionGeoFields` and updated the model snapshot to persist the new columns. 
- Extended `VisitorSessionListItemViewModel` and `AnalyticsIndexViewModel` to carry geo values and a `TopCountries` collection. 
- Updated `AnalyticsController` queries/projections to include geo fields and to compute the `TopCountries` breakdown from non-empty country values, and passed the data through to the view. 
- Updated `Areas/Admin/Views/Analytics/Index.cshtml` to add a Top Countries card and to show `Country` and `City` columns in the Visitor Sessions table with a safe fallback (`—`) when values are empty. 

### Testing
- Generated and added the EF migration file `AddVisitorSessionGeoFields` to the repository (migration file present). 
- Attempted to run EF tooling (`dotnet ef`) in this environment but `dotnet` is not installed here, so the migration could not be applied or runtime build/tests executed. 
- No automated test failures were observed from static edits; runtime integration (build/migrations) should be validated in CI or a local environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa048cb89c832bbfff771f07fe58cb)