### PR TITLE
Add conversion funnel analytics to Admin dashboard

### DIFF
--- a/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
+++ b/CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs
@@ -257,6 +257,107 @@ public class AnalyticsController : Controller
             .Take(10)
             .ToListAsync();
 
+
+        var funnelVisits = await _context.PageVisits
+            .AsNoTracking()
+            .Where(x => x.VisitedAt >= filterStart && x.VisitedAt < filterEndExclusive)
+            .Select(x => new { x.VisitorSessionId, x.Path, x.VisitedAt })
+            .ToListAsync();
+
+        var funnelStepDefinitions = new[]
+        {
+            new { Name = "Home", Matches = new Func<string, bool>(path => string.Equals(path, "/", StringComparison.OrdinalIgnoreCase) || string.Equals(path, "/Home", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/Home/", StringComparison.OrdinalIgnoreCase)) },
+            new { Name = "Servers/VPS/VDI", Matches = new Func<string, bool>(path => path.StartsWith("/Servers", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/VPS", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/VDI", StringComparison.OrdinalIgnoreCase)) },
+            new { Name = "Cart/Checkout", Matches = new Func<string, bool>(path => path.StartsWith("/Cart", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/Orders/Create", StringComparison.OrdinalIgnoreCase)) },
+            new { Name = "Contact/Order", Matches = new Func<string, bool>(path => path.StartsWith("/Contact", StringComparison.OrdinalIgnoreCase) || path.StartsWith("/Orders", StringComparison.OrdinalIgnoreCase)) }
+        };
+
+        var sessionSteps = new Dictionary<int, HashSet<int>>();
+        foreach (var visit in funnelVisits)
+        {
+            for (var index = 0; index < funnelStepDefinitions.Length; index++)
+            {
+                if (!funnelStepDefinitions[index].Matches(visit.Path))
+                {
+                    continue;
+                }
+
+                if (!sessionSteps.TryGetValue(visit.VisitorSessionId, out var reachedSteps))
+                {
+                    reachedSteps = new HashSet<int>();
+                    sessionSteps[visit.VisitorSessionId] = reachedSteps;
+                }
+
+                reachedSteps.Add(index);
+                break;
+            }
+        }
+
+        var funnelVisitorsByStep = new int[funnelStepDefinitions.Length];
+        var exitCountsByStep = new int[funnelStepDefinitions.Length];
+
+        foreach (var (_, reachedSteps) in sessionSteps)
+        {
+            for (var step = 0; step < funnelStepDefinitions.Length; step++)
+            {
+                var reachedCurrent = reachedSteps.Contains(step);
+                if (reachedCurrent)
+                {
+                    funnelVisitorsByStep[step]++;
+                }
+
+                if (!reachedCurrent)
+                {
+                    continue;
+                }
+
+                if (step == funnelStepDefinitions.Length - 1 || !reachedSteps.Contains(step + 1))
+                {
+                    exitCountsByStep[step]++;
+                }
+            }
+        }
+
+        var funnelSteps = new List<FunnelStepViewModel>(funnelStepDefinitions.Length);
+        for (var step = 0; step < funnelStepDefinitions.Length; step++)
+        {
+            var visitorsCount = funnelVisitorsByStep[step];
+            decimal dropOffPercentage;
+            if (step == funnelStepDefinitions.Length - 1)
+            {
+                dropOffPercentage = 0;
+            }
+            else if (visitorsCount == 0)
+            {
+                dropOffPercentage = 0;
+            }
+            else
+            {
+                var nextVisitors = funnelVisitorsByStep[step + 1];
+                dropOffPercentage = Math.Round((visitorsCount - nextVisitors) * 100m / visitorsCount, 2);
+            }
+
+            funnelSteps.Add(new FunnelStepViewModel
+            {
+                Name = funnelStepDefinitions[step].Name,
+                Visitors = visitorsCount,
+                DropOffPercentage = dropOffPercentage
+            });
+        }
+
+        var topExitStep = "—";
+        var maxExitCount = 0;
+        for (var step = 0; step < exitCountsByStep.Length; step++)
+        {
+            if (exitCountsByStep[step] <= maxExitCount)
+            {
+                continue;
+            }
+
+            maxExitCount = exitCountsByStep[step];
+            topExitStep = funnelStepDefinitions[step].Name;
+        }
+
         var totalPageVisits = await _context.PageVisits
             .AsNoTracking()
             .Where(x => x.VisitedAt >= filterStart && x.VisitedAt < filterEndExclusive)
@@ -317,7 +418,9 @@ public class AnalyticsController : Controller
             TopPages = topPages,
             TopBrowsers = topBrowsers,
             TopCountries = topCountries,
-            DeviceSplit = deviceSplit
+            DeviceSplit = deviceSplit,
+            FunnelSteps = funnelSteps,
+            TopExitStep = topExitStep
         });
     }
 

--- a/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
+++ b/CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml
@@ -109,6 +109,41 @@
 
             <div class="card mb-3">
                 <div class="card-body">
+                    <h5 class="card-title">Conversion Funnel</h5>
+                    <p class="mb-3">Top exit step: <strong>@Model.TopExitStep</strong></p>
+                    @if (Model.FunnelSteps.Count == 0)
+                    {
+                        <div class="alert alert-info mb-0">No funnel data found for selected range.</div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover table-bordered align-middle mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Step</th>
+                                        <th>Visitors</th>
+                                        <th>Drop-off</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                @foreach (var step in Model.FunnelSteps)
+                                {
+                                    <tr>
+                                        <td>@step.Name</td>
+                                        <td>@step.Visitors</td>
+                                        <td>@step.DropOffPercentage.ToString("0.##")%</td>
+                                    </tr>
+                                }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-body">
                     <h5 class="card-title">Active Visitors (Last 5 Minutes)</h5>
                     @if (Model.ActiveVisitors.Count == 0)
                     {

--- a/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
+++ b/CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs
@@ -15,6 +15,15 @@ public sealed class AnalyticsIndexViewModel
     public IReadOnlyList<AnalyticsBreakdownItemViewModel> TopCountries { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
     public IReadOnlyList<AnalyticsBreakdownItemViewModel> DeviceSplit { get; init; } = Array.Empty<AnalyticsBreakdownItemViewModel>();
     public IReadOnlyList<SuspiciousActivityListItemViewModel> SuspiciousActivities { get; init; } = Array.Empty<SuspiciousActivityListItemViewModel>();
+    public IReadOnlyList<FunnelStepViewModel> FunnelSteps { get; init; } = Array.Empty<FunnelStepViewModel>();
+    public string TopExitStep { get; init; } = "—";
+}
+
+public sealed class FunnelStepViewModel
+{
+    public string Name { get; init; } = string.Empty;
+    public int Visitors { get; init; }
+    public decimal DropOffPercentage { get; init; }
 }
 
 public sealed class AnalyticsBreakdownItemViewModel


### PR DESCRIPTION
### Motivation

- Provide admins with visibility into where users leave the site by adding a simple conversion funnel from Home → Servers/VPS/VDI → Cart/Checkout → Contact/Order.

### Description

- Added `FunnelSteps` and `TopExitStep` to `AnalyticsIndexViewModel` and introduced `FunnelStepViewModel` to carry per-step metrics.
- Implemented funnel computation in `AnalyticsController` by scanning `PageVisits` in the selected date window, mapping sessions to funnel steps, counting unique visitors per step, computing per-step drop-off percentages, and detecting the top exit step.
- Updated the Admin Analytics UI (`Areas/Admin/Views/Analytics/Index.cshtml`) with a new "Conversion Funnel" card that displays step name, visitors, drop-off percentage, and top exit step.
- Changes touch `CloudCityCenter/Areas/Admin/Controllers/AnalyticsController.cs`, `CloudCityCenter/Models/Admin/AnalyticsIndexViewModel.cs`, and `CloudCityCenter/Areas/Admin/Views/Analytics/Index.cshtml`.

### Testing

- Attempted to run `dotnet build CloudCityCenter.sln` but the build could not be executed in this environment because the `dotnet` CLI is not installed (build not run).
- Changes were staged and committed locally with `git` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0593ae50832b8d2312b943fe7177)