### PR TITLE
Add GeoIP lookup and persistence for visitor sessions

### DIFF
--- a/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
+++ b/CloudCityCenter/Middleware/VisitorTrackingMiddleware.cs
@@ -14,11 +14,13 @@ public class VisitorTrackingMiddleware
 
     private readonly RequestDelegate _next;
     private readonly ILogger<VisitorTrackingMiddleware> _logger;
+    private readonly IGeoIpService _geoIpService;
 
-    public VisitorTrackingMiddleware(RequestDelegate next, ILogger<VisitorTrackingMiddleware> logger)
+    public VisitorTrackingMiddleware(RequestDelegate next, ILogger<VisitorTrackingMiddleware> logger, IGeoIpService geoIpService)
     {
         _next = next;
         _logger = logger;
+        _geoIpService = geoIpService;
     }
 
     public async Task InvokeAsync(HttpContext context, ApplicationDbContext dbContext)
@@ -60,6 +62,17 @@ public class VisitorTrackingMiddleware
                     if (!string.IsNullOrWhiteSpace(referrer))
                     {
                         existingSession.Referrer = referrer;
+                    }
+                }
+
+                if (string.IsNullOrWhiteSpace(existingSession.Country))
+                {
+                    var geo = await _geoIpService.LookupAsync(normalizedIp, context.RequestAborted);
+                    if (geo is not null)
+                    {
+                        existingSession.Country = geo.Country;
+                        existingSession.CountryCode = geo.CountryCode;
+                        existingSession.City = geo.City;
                     }
                 }
 

--- a/CloudCityCenter/Program.cs
+++ b/CloudCityCenter/Program.cs
@@ -68,6 +68,12 @@ builder.Services
     .AddRoles<IdentityRole>()                // добавить
     .AddEntityFrameworkStores<ApplicationDbContext>();
 
+builder.Services.AddHttpClient<IGeoIpService, IpApiGeoIpService>(client =>
+{
+    client.BaseAddress = new Uri("http://ip-api.com/");
+    client.Timeout = TimeSpan.FromSeconds(3);
+});
+
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession(options =>
 {

--- a/CloudCityCenter/Services/GeoIpLookupResult.cs
+++ b/CloudCityCenter/Services/GeoIpLookupResult.cs
@@ -1,0 +1,3 @@
+namespace CloudCityCenter.Services;
+
+public sealed record GeoIpLookupResult(string? Country, string? CountryCode, string? City);

--- a/CloudCityCenter/Services/IGeoIpService.cs
+++ b/CloudCityCenter/Services/IGeoIpService.cs
@@ -1,0 +1,6 @@
+namespace CloudCityCenter.Services;
+
+public interface IGeoIpService
+{
+    Task<GeoIpLookupResult?> LookupAsync(string ipAddress, CancellationToken cancellationToken = default);
+}

--- a/CloudCityCenter/Services/IpApiGeoIpService.cs
+++ b/CloudCityCenter/Services/IpApiGeoIpService.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Text.Json;
+
+namespace CloudCityCenter.Services;
+
+public sealed class IpApiGeoIpService : IGeoIpService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<IpApiGeoIpService> _logger;
+
+    public IpApiGeoIpService(HttpClient httpClient, ILogger<IpApiGeoIpService> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<GeoIpLookupResult?> LookupAsync(string ipAddress, CancellationToken cancellationToken = default)
+    {
+        if (!TryParsePublicIp(ipAddress, out _))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var response = await _httpClient.GetAsync($"json/{ipAddress}", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("GeoIP lookup failed for {IpAddress}. Status code: {StatusCode}", ipAddress, response.StatusCode);
+                return null;
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            var payload = await JsonSerializer.DeserializeAsync<IpApiResponse>(stream, cancellationToken: cancellationToken);
+            if (payload is null || !string.Equals(payload.Status, "success", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("GeoIP lookup returned unsuccessful payload for {IpAddress}. Status: {Status}", ipAddress, payload?.Status);
+                return null;
+            }
+
+            return new GeoIpLookupResult(
+                Clean(payload.Country),
+                Clean(payload.CountryCode),
+                Clean(payload.City));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "GeoIP lookup threw exception for {IpAddress}", ipAddress);
+            return null;
+        }
+    }
+
+    private static bool TryParsePublicIp(string ipAddress, out IPAddress parsedIp)
+    {
+        parsedIp = IPAddress.None;
+        if (!IPAddress.TryParse(ipAddress, out parsedIp))
+        {
+            return false;
+        }
+
+        if (parsedIp.IsIPv4MappedToIPv6)
+        {
+            parsedIp = parsedIp.MapToIPv4();
+        }
+
+        if (IPAddress.IsLoopback(parsedIp))
+        {
+            return false;
+        }
+
+        if (parsedIp.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
+        {
+            return !parsedIp.IsIPv6LinkLocal && !parsedIp.IsIPv6SiteLocal && !parsedIp.IsIPv6Multicast;
+        }
+
+        var bytes = parsedIp.GetAddressBytes();
+        if (bytes[0] == 10)
+        {
+            return false;
+        }
+
+        if (bytes[0] == 192 && bytes[1] == 168)
+        {
+            return false;
+        }
+
+        return !(bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31);
+    }
+
+    private static string? Clean(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private sealed class IpApiResponse
+    {
+        public string? Status { get; set; }
+        public string? Country { get; set; }
+        public string? CountryCode { get; set; }
+        public string? City { get; set; }
+    }
+}


### PR DESCRIPTION
### Motivation
- Populate analytics `Country`, `CountryCode` and `City` fields for visitor sessions so admin dashboards show real geolocation data.
- Use a free, no-auth provider (first choice `http://ip-api.com/json/{ip}`) to avoid adding credentials and keep the integration simple.
- Avoid calling the GeoIP provider on every request and skip lookups for private/local IP ranges so performance and privacy are preserved.

### Description
- Added a lookup DTO `GeoIpLookupResult` and an abstraction `IGeoIpService` to encapsulate GeoIP lookups.
- Implemented `IpApiGeoIpService` which calls `http://ip-api.com/json/{ip}`, maps `Country`, `CountryCode`, and `City`, filters private/local IPs, and returns `null` on failure while logging warnings.
- Registered the service with `builder.Services.AddHttpClient<IGeoIpService, IpApiGeoIpService>` using `BaseAddress = new Uri("http://ip-api.com/")` and a short timeout to keep requests bounded.
- Updated `VisitorTrackingMiddleware` to inject `IGeoIpService` and enrich `VisitorSession` with `Country`, `CountryCode`, and `City` only when a session is first created or when `Country` is null, and to persist the values safely without breaking the request pipeline.

### Testing
- Attempted to build with `dotnet build CloudCityCenter.sln`, but the command failed in this environment because `dotnet` is not installed (`/bin/bash: line 1: dotnet: command not found`).
- No other automated tests were executed in this environment; runtime behavior should be validated in an environment with the .NET SDK and access to the GeoIP provider.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa071e9e58832ba92dddc7cb163257)