### PR TITLE
Add CloudCity Coin landing page, route, header link and styles

### DIFF
--- a/CloudCityCenter/Controllers/CoinController.cs
+++ b/CloudCityCenter/Controllers/CoinController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CloudCityCenter.Controllers;
+
+[AllowAnonymous]
+public class CoinController : Controller
+{
+    [HttpGet("coin")]
+    [HttpGet("cloudcity-coin")]
+    public IActionResult Index()
+    {
+        ViewData["Title"] = "CloudCity Coin";
+        ViewData["Description"] = "CloudCity Coin is the digital coin of the CloudCity ecosystem and a planned additional payment option for selected CloudCity services.";
+        ViewData["Keywords"] = "CloudCity Coin, CloudCity crypto, Solana coin, CloudCity payment option";
+
+        return View();
+    }
+}

--- a/CloudCityCenter/Views/Coin/Index.cshtml
+++ b/CloudCityCenter/Views/Coin/Index.cshtml
@@ -1,0 +1,70 @@
+@{
+    var coinUrl = "https://pump.fun/coin/2xK1RUw3MXuMyQKQWcyadAkeUKh96RdUt1EuPbXXpump";
+}
+
+<div class="coin-page">
+    <section class="coin-hero glass-panel">
+        <p class="coin-kicker"><i class="bi bi-hexagon"></i> CloudCity Ecosystem</p>
+        <h1>CloudCity Coin</h1>
+        <p class="coin-subtitle">The digital coin of the CloudCity ecosystem.</p>
+        <p class="coin-description">
+            CloudCity Coin is created as part of the CloudCity brand ecosystem and is planned to be used as an additional payment option for selected CloudCity services.
+        </p>
+        <div class="coin-hero-actions">
+            <a class="btn btn-primary coin-btn" href="@coinUrl" target="_blank" rel="noopener noreferrer">Buy CloudCity Coin</a>
+            <a class="btn btn-outline-light coin-btn" href="#how-to-buy">How to buy</a>
+        </div>
+    </section>
+
+    <section class="coin-section">
+        <h2>Why CloudCity Coin</h2>
+        <div class="coin-grid">
+            <article class="coin-card">
+                <i class="bi bi-credit-card-2-front"></i>
+                <h3>Future payment option</h3>
+                <p>Planned to support payments for selected CloudCity services.</p>
+            </article>
+            <article class="coin-card">
+                <i class="bi bi-buildings"></i>
+                <h3>CloudCity ecosystem</h3>
+                <p>Developed as a natural part of the wider CloudCity company ecosystem.</p>
+            </article>
+            <article class="coin-card">
+                <i class="bi bi-people"></i>
+                <h3>Community focused</h3>
+                <p>Built for clients, partners, and supporters of the CloudCity community.</p>
+            </article>
+            <article class="coin-card">
+                <i class="bi bi-wallet2"></i>
+                <h3>Simple to buy</h3>
+                <p>Purchase on Pump.fun using a Solana wallet in just a few steps.</p>
+            </article>
+        </div>
+    </section>
+
+    <section id="how-to-buy" class="coin-section">
+        <h2>How to buy CloudCity Coin</h2>
+        <div class="coin-steps">
+            <div class="coin-step"><span>1</span><div><h3>Install Phantom Wallet</h3><p>Set up a Solana-compatible wallet such as Phantom.</p></div></div>
+            <div class="coin-step"><span>2</span><div><h3>Add SOL to your wallet</h3><p>You need SOL to buy the coin and pay Solana network fees.</p></div></div>
+            <div class="coin-step"><span>3</span><div><h3>Open the CloudCity Coin page on Pump.fun</h3><p><a href="@coinUrl" target="_blank" rel="noopener noreferrer">@coinUrl</a></p></div></div>
+            <div class="coin-step"><span>4</span><div><h3>Connect wallet</h3><p>Connect your wallet to Pump.fun on the coin page.</p></div></div>
+            <div class="coin-step"><span>5</span><div><h3>Enter amount and buy</h3><p>Choose how much SOL you want to spend and confirm the transaction.</p></div></div>
+            <div class="coin-step"><span>6</span><div><h3>Keep the coin in your wallet</h3><p>After purchase, your CloudCity Coin balance will be visible in the wallet.</p></div></div>
+        </div>
+    </section>
+
+    <section class="coin-section">
+        <div class="coin-payment-box glass-panel">
+            <h2>Pay for CloudCity services with CloudCity Coin</h2>
+            <p>CloudCity Coin is planned to become an additional payment option for selected CloudCity services. This allows clients and supporters of the CloudCity ecosystem to hold and use the coin inside the company’s service model.</p>
+            <a class="btn btn-primary coin-btn" asp-controller="Contact" asp-action="Index">Contact us to pay with CloudCity Coin</a>
+        </div>
+    </section>
+
+    <section class="coin-disclaimer">
+        <p>
+            CloudCity Coin is a crypto asset and may be highly volatile. This page is for informational purposes only and is not financial advice. Please do your own research before buying.
+        </p>
+    </section>
+</div>

--- a/CloudCityCenter/Views/Shared/_Layout.cshtml
+++ b/CloudCityCenter/Views/Shared/_Layout.cshtml
@@ -175,6 +175,11 @@
                                 <i class="bi bi-gear me-1"></i>@Localizer["Services"]
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link @(currentController == "Coin" ? "active" : "")" asp-area="" asp-controller="Coin" asp-action="Index">
+                                <i class="bi bi-currency-bitcoin me-1"></i>CloudCity Coin
+                            </a>
+                        </li>
                     </ul>
 
                     <!-- Center - Social Media Icons -->
@@ -348,6 +353,11 @@
                     <li class="nav-item">
                         <a class="nav-link @(string.Equals(currentController, "VDI", StringComparison.OrdinalIgnoreCase) ? "active" : "")" asp-area="" asp-controller="VDI" asp-action="Index" data-offcanvas-close>
                             <i class="bi bi-display me-2"></i>@Localizer["VDI"]
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link @(currentController == "Coin" ? "active" : "")" asp-area="" asp-controller="Coin" asp-action="Index" data-offcanvas-close>
+                            <i class="bi bi-currency-bitcoin me-2"></i>CloudCity Coin
                         </a>
                     </li>
                     <li class="nav-item">

--- a/CloudCityCenter/wwwroot/css/site.css
+++ b/CloudCityCenter/wwwroot/css/site.css
@@ -11812,3 +11812,40 @@ li.dropdown.show .dropdown-menu {
 .btn-register-mobile:hover i {
   transform: scale(1.2) rotate(10deg);
 }
+
+/* CloudCity Coin landing page */
+.coin-page { padding: 2rem 0 4rem; color: #f3f7ff; }
+.coin-section { margin-top: 2.5rem; }
+.glass-panel {
+    background: linear-gradient(145deg, rgba(13, 27, 56, 0.85), rgba(12, 19, 43, 0.72));
+    border: 1px solid rgba(120, 184, 255, 0.24);
+    border-radius: 1.2rem;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+.coin-hero { padding: 2.5rem 1.5rem; text-align: center; }
+.coin-kicker { color: #8fc3ff; letter-spacing: .06em; text-transform: uppercase; font-size: .85rem; font-weight: 600; }
+.coin-hero h1 { font-size: clamp(2rem, 6vw, 3.4rem); font-weight: 800; margin-bottom: .6rem; }
+.coin-subtitle { font-size: clamp(1.1rem, 3vw, 1.4rem); color: #c6dcff; margin-bottom: .8rem; }
+.coin-description { max-width: 760px; margin: 0 auto; color: #deebff; }
+.coin-hero-actions { display: flex; gap: .8rem; justify-content: center; flex-wrap: wrap; margin-top: 1.5rem; }
+.coin-btn { border-radius: 999px; padding: .75rem 1.25rem; font-weight: 600; }
+.coin-grid { display: grid; grid-template-columns: 1fr; gap: 1rem; margin-top: 1rem; }
+.coin-card { background: rgba(11, 21, 43, 0.78); border: 1px solid rgba(119, 182, 255, 0.2); border-radius: 1rem; padding: 1.1rem; }
+.coin-card i { font-size: 1.4rem; color: #7ab8ff; }
+.coin-card h3 { margin-top: .55rem; font-size: 1.1rem; }
+.coin-card p { color: #d6e6ff; margin-bottom: 0; }
+.coin-steps { margin-top: 1rem; display: grid; gap: .9rem; }
+.coin-step { display: grid; grid-template-columns: 42px 1fr; gap: .8rem; align-items: start; background: rgba(10, 19, 39, 0.75); border: 1px solid rgba(98, 168, 250, 0.2); border-radius: .9rem; padding: .95rem; }
+.coin-step span { width: 42px; height: 42px; border-radius: 50%; background: #1f6feb; color: #fff; display: inline-flex; align-items: center; justify-content: center; font-weight: 700; }
+.coin-step h3 { margin: .1rem 0 .3rem; font-size: 1.05rem; }
+.coin-step p { color: #d8e7ff; margin-bottom: 0; }
+.coin-step a { color: #8bc1ff; word-break: break-all; }
+.coin-payment-box { padding: 1.7rem 1.2rem; }
+.coin-payment-box p { color: #d7e7ff; }
+.coin-disclaimer { margin-top: 2rem; padding: 1rem 1.1rem; border-left: 3px solid #66aaff; background: rgba(18, 26, 52, 0.65); border-radius: .5rem; color: #cfe2ff; }
+
+@media (min-width: 768px) {
+    .coin-hero { padding: 3.2rem 2.5rem; }
+    .coin-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .coin-payment-box { padding: 2.2rem; }
+}


### PR DESCRIPTION
### Motivation
- Provide a public, brand-consistent sales landing page for CloudCity Coin so visitors can learn about the coin and purchase it via Pump.fun.
- Surface the coin in the main navigation for discoverability across desktop and mobile.
- Reuse existing site layout and visual language to keep the page consistent with CloudCity branding.

### Description
- Added a new public `CoinController` with anonymous access and route aliases for `/coin` and `/cloudcity-coin`, and populated SEO `ViewData` (`Title`, `Description`, `Keywords`).
- Created a new Razor view `Views/Coin/Index.cshtml` containing the hero (title, subtitle, description), primary CTA to the Pump.fun purchase link, secondary CTA to the how-to section, value-proposition cards, a 6-step "How to buy" flow, a payment-use section with contact CTA, and a risk disclaimer.
- Inserted a "CloudCity Coin" link into the main header navigation for both desktop and mobile, wired to `CoinController.Index` for consistent site routing.
- Added scoped responsive dark/premium styles to `wwwroot/css/site.css` for the coin page (glass-panel, cards, steps, CTAs) and ensured external Pump.fun links include `target="_blank"` and `rel="noopener noreferrer"`.

### Testing
- Attempted `dotnet build` for `CloudCityCenter.sln`, but the environment does not have `dotnet` installed so the build could not be executed (failed with `/bin/bash: dotnet: command not found`).
- Manual verification checks in the repository confirmed the new controller, view, layout changes, and CSS additions are present and correctly referenced; runtime build verification should be performed in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac8ee66e0832ba2c0ef977e283a66)