### PR TITLE
Localize CloudCity Coin page for EN/RU/UK with localized SEO

### DIFF
--- a/CloudCityCenter/Controllers/CoinController.cs
+++ b/CloudCityCenter/Controllers/CoinController.cs
@@ -1,18 +1,32 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
 
 namespace CloudCityCenter.Controllers;
 
 [AllowAnonymous]
 public class CoinController : Controller
 {
+    private readonly IStringLocalizerFactory _localizerFactory;
+
+    public CoinController(IStringLocalizerFactory localizerFactory)
+    {
+        _localizerFactory = localizerFactory;
+    }
+
+    private IStringLocalizer GetLocalizer()
+    {
+        return _localizerFactory.Create("Views.Coin.Index", "CloudCityCenter");
+    }
+
     [HttpGet("coin")]
     [HttpGet("cloudcity-coin")]
     public IActionResult Index()
     {
-        ViewData["Title"] = "CloudCity Coin";
-        ViewData["Description"] = "CloudCity Coin is the digital coin of the CloudCity ecosystem and a planned additional payment option for selected CloudCity services.";
-        ViewData["Keywords"] = "CloudCity Coin, CloudCity crypto, Solana coin, CloudCity payment option";
+        var localizer = GetLocalizer();
+        ViewData["Title"] = localizer["SEOTitle"].Value;
+        ViewData["Description"] = localizer["SEODescription"].Value;
+        ViewData["Keywords"] = localizer["SEOKeywords"].Value;
 
         return View();
     }

--- a/CloudCityCenter/Resources/Views/Coin/Index.resx
+++ b/CloudCityCenter/Resources/Views/Coin/Index.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="HeroBadge" xml:space="preserve"><value>CloudCity Ecosystem</value></data>
+  <data name="HeroTitle" xml:space="preserve"><value>CloudCity Coin</value></data>
+  <data name="HeroSubtitle" xml:space="preserve"><value>Digital payment asset for the CloudCity ecosystem</value></data>
+  <data name="HeroDescription" xml:space="preserve"><value>CloudCity Coin connects Web3-native payments with practical cloud infrastructure services, helping clients move between crypto and compute in one modern ecosystem.</value></data>
+  <data name="HeroPrimaryCta" xml:space="preserve"><value>Buy CloudCity Coin</value></data>
+  <data name="HeroSecondaryCta" xml:space="preserve"><value>How to Buy</value></data>
+  <data name="WhyTitle" xml:space="preserve"><value>Why CloudCity Coin</value></data>
+  <data name="WhyCard1Title" xml:space="preserve"><value>Fast payments</value></data>
+  <data name="WhyCard1Description" xml:space="preserve"><value>Speed-first Solana transactions for modern cloud commerce.</value></data>
+  <data name="WhyCard2Title" xml:space="preserve"><value>Ecosystem-native</value></data>
+  <data name="WhyCard2Description" xml:space="preserve"><value>Aligned with CloudCity infrastructure and service growth.</value></data>
+  <data name="WhyCard3Title" xml:space="preserve"><value>Secure flow</value></data>
+  <data name="WhyCard3Description" xml:space="preserve"><value>Wallet-signature transactions and transparent on-chain records.</value></data>
+  <data name="EcosystemTitle" xml:space="preserve"><value>Service Ecosystem Utility</value></data>
+  <data name="ServiceCard1Title" xml:space="preserve"><value>VPS</value></data>
+  <data name="ServiceCard1Description" xml:space="preserve"><value>Compute instances for scalable workloads.</value></data>
+  <data name="ServiceCard2Title" xml:space="preserve"><value>VDI</value></data>
+  <data name="ServiceCard2Description" xml:space="preserve"><value>Cloud desktops for distributed teams.</value></data>
+  <data name="ServiceCard3Title" xml:space="preserve"><value>Windows Server</value></data>
+  <data name="ServiceCard3Description" xml:space="preserve"><value>Managed Windows infrastructure layers.</value></data>
+  <data name="ServiceCard4Title" xml:space="preserve"><value>VPN</value></data>
+  <data name="ServiceCard4Description" xml:space="preserve"><value>Secure private network tunneling.</value></data>
+  <data name="ServiceCard5Title" xml:space="preserve"><value>Web Hosting</value></data>
+  <data name="ServiceCard5Description" xml:space="preserve"><value>Reliable web hosting with modern stack options.</value></data>
+  <data name="ServiceCard6Title" xml:space="preserve"><value>Security</value></data>
+  <data name="ServiceCard6Description" xml:space="preserve"><value>Protection-first architecture and monitoring.</value></data>
+  <data name="HowToBuyTitle" xml:space="preserve"><value>How to Buy</value></data>
+  <data name="Step1Title" xml:space="preserve"><value>Install Phantom Wallet</value></data>
+  <data name="Step1Description" xml:space="preserve"><value>Install and create your wallet securely.</value></data>
+  <data name="Step2Title" xml:space="preserve"><value>Add SOL</value></data>
+  <data name="Step2Description" xml:space="preserve"><value>Fund wallet with SOL for purchase + network fees.</value></data>
+  <data name="Step3Title" xml:space="preserve"><value>Open Pump.fun page</value></data>
+  <data name="Step3LinkText" xml:space="preserve"><value>Official CloudCity Coin buy link</value></data>
+  <data name="Step4Title" xml:space="preserve"><value>Connect wallet</value></data>
+  <data name="Step4Description" xml:space="preserve"><value>Authorize wallet connection in Pump.fun.</value></data>
+  <data name="Step5Title" xml:space="preserve"><value>Buy Coin</value></data>
+  <data name="Step5Description" xml:space="preserve"><value>Select amount and confirm transaction.</value></data>
+  <data name="Step6Title" xml:space="preserve"><value>Hold inside wallet</value></data>
+  <data name="Step6Description" xml:space="preserve"><value>Tokens remain visible and controlled in your wallet.</value></data>
+  <data name="UseCasesTitle" xml:space="preserve"><value>Payment Use Cases</value></data>
+  <data name="UseCase1Title" xml:space="preserve"><value>Infrastructure orders</value></data>
+  <data name="UseCase1Description" xml:space="preserve"><value>Use coin-based payments for eligible compute or hosting orders.</value></data>
+  <data name="UseCase2Title" xml:space="preserve"><value>Subscription support</value></data>
+  <data name="UseCase2Description" xml:space="preserve"><value>Future-ready token flow for recurring cloud services.</value></data>
+  <data name="UseCase3Title" xml:space="preserve"><value>Partner ecosystem</value></data>
+  <data name="UseCase3Description" xml:space="preserve"><value>Utility across CloudCity-aligned offerings and campaigns.</value></data>
+  <data name="FaqTitle" xml:space="preserve"><value>FAQ</value></data>
+  <data name="Faq1Question" xml:space="preserve"><value>What is CloudCity Coin?</value></data>
+  <data name="Faq1Answer" xml:space="preserve"><value>A digital payment asset designed for CloudCity ecosystem utility.</value></data>
+  <data name="Faq2Question" xml:space="preserve"><value>Where do I buy it?</value></data>
+  <data name="Faq2Answer" xml:space="preserve"><value>On the official Pump.fun page linked above.</value></data>
+  <data name="Faq3Question" xml:space="preserve"><value>Do I need Phantom?</value></data>
+  <data name="Faq3Answer" xml:space="preserve"><value>You need any Solana-compatible wallet; Phantom is common.</value></data>
+  <data name="FinalCtaTitle" xml:space="preserve"><value>Join the CloudCity Coin ecosystem</value></data>
+  <data name="FinalCtaDescription" xml:space="preserve"><value>Enter a premium cloud + crypto environment built for digital-first payments.</value></data>
+  <data name="RiskDisclaimer" xml:space="preserve"><value>Risk disclaimer: Digital assets are volatile. Always do your own research before any purchase.</value></data>
+  <data name="FinalPrimaryCta" xml:space="preserve"><value>Buy CloudCity Coin</value></data>
+  <data name="FinalSecondaryCta" xml:space="preserve"><value>Contact CloudCity</value></data>
+  <data name="SEOTitle" xml:space="preserve"><value>CloudCity Coin - CloudCityCenter</value></data>
+  <data name="SEODescription" xml:space="preserve"><value>CloudCity Coin is a digital payment asset in the CloudCity ecosystem, with utility across selected infrastructure and cloud services.</value></data>
+  <data name="SEOKeywords" xml:space="preserve"><value>CloudCity Coin, CloudCity crypto, Solana coin, cloud payment asset</value></data>
+</root>

--- a/CloudCityCenter/Resources/Views/Coin/Index.ru.resx
+++ b/CloudCityCenter/Resources/Views/Coin/Index.ru.resx
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <data name="HeroBadge" xml:space="preserve"><value>Экосистема CloudCity</value></data>
+  <data name="HeroTitle" xml:space="preserve"><value>CloudCity Coin</value></data>
+  <data name="HeroSubtitle" xml:space="preserve"><value>Цифровой платежный актив для экосистемы CloudCity</value></data>
+  <data name="HeroDescription" xml:space="preserve"><value>CloudCity Coin объединяет Web3-платежи с практичными облачными инфраструктурными сервисами, помогая клиентам работать с криптоактивами и вычислительными ресурсами в единой современной экосистеме.</value></data>
+  <data name="HeroPrimaryCta" xml:space="preserve"><value>Купить CloudCity Coin</value></data>
+  <data name="HeroSecondaryCta" xml:space="preserve"><value>Как купить</value></data>
+  <data name="WhyTitle" xml:space="preserve"><value>Почему CloudCity Coin</value></data>
+  <data name="WhyCard1Title" xml:space="preserve"><value>Быстрые платежи</value></data>
+  <data name="WhyCard1Description" xml:space="preserve"><value>Быстрые транзакции Solana для современной облачной коммерции.</value></data>
+  <data name="WhyCard2Title" xml:space="preserve"><value>Нативно для экосистемы</value></data>
+  <data name="WhyCard2Description" xml:space="preserve"><value>Синхронизирован с ростом инфраструктуры и сервисов CloudCity.</value></data>
+  <data name="WhyCard3Title" xml:space="preserve"><value>Безопасный процесс</value></data>
+  <data name="WhyCard3Description" xml:space="preserve"><value>Транзакции с подписью кошелька и прозрачные записи в блокчейне.</value></data>
+  <data name="EcosystemTitle" xml:space="preserve"><value>Полезность в сервисной экосистеме</value></data>
+  <data name="ServiceCard1Title" xml:space="preserve"><value>VPS</value></data>
+  <data name="ServiceCard1Description" xml:space="preserve"><value>Вычислительные инстансы для масштабируемых нагрузок.</value></data>
+  <data name="ServiceCard2Title" xml:space="preserve"><value>VDI</value></data>
+  <data name="ServiceCard2Description" xml:space="preserve"><value>Облачные рабочие столы для распределенных команд.</value></data>
+  <data name="ServiceCard3Title" xml:space="preserve"><value>Windows Server</value></data>
+  <data name="ServiceCard3Description" xml:space="preserve"><value>Управляемые слои инфраструктуры Windows.</value></data>
+  <data name="ServiceCard4Title" xml:space="preserve"><value>VPN</value></data>
+  <data name="ServiceCard4Description" xml:space="preserve"><value>Безопасное частное сетевое туннелирование.</value></data>
+  <data name="ServiceCard5Title" xml:space="preserve"><value>Web Hosting</value></data>
+  <data name="ServiceCard5Description" xml:space="preserve"><value>Надежный веб-хостинг с современными стек-опциями.</value></data>
+  <data name="ServiceCard6Title" xml:space="preserve"><value>Security</value></data>
+  <data name="ServiceCard6Description" xml:space="preserve"><value>Архитектура и мониторинг с приоритетом защиты.</value></data>
+  <data name="HowToBuyTitle" xml:space="preserve"><value>Как купить</value></data>
+  <data name="Step1Title" xml:space="preserve"><value>Установите Phantom Wallet</value></data>
+  <data name="Step1Description" xml:space="preserve"><value>Установите и безопасно создайте кошелек.</value></data>
+  <data name="Step2Title" xml:space="preserve"><value>Пополните SOL</value></data>
+  <data name="Step2Description" xml:space="preserve"><value>Пополните кошелек SOL для покупки и сетевых комиссий.</value></data>
+  <data name="Step3Title" xml:space="preserve"><value>Откройте страницу Pump.fun</value></data>
+  <data name="Step3LinkText" xml:space="preserve"><value>Официальная ссылка на покупку CloudCity Coin</value></data>
+  <data name="Step4Title" xml:space="preserve"><value>Подключите кошелек</value></data>
+  <data name="Step4Description" xml:space="preserve"><value>Подтвердите подключение кошелька в Pump.fun.</value></data>
+  <data name="Step5Title" xml:space="preserve"><value>Купите монету</value></data>
+  <data name="Step5Description" xml:space="preserve"><value>Выберите сумму и подтвердите транзакцию.</value></data>
+  <data name="Step6Title" xml:space="preserve"><value>Храните в кошельке</value></data>
+  <data name="Step6Description" xml:space="preserve"><value>Токены остаются видимыми и под вашим контролем в кошельке.</value></data>
+  <data name="UseCasesTitle" xml:space="preserve"><value>Сценарии оплаты</value></data>
+  <data name="UseCase1Title" xml:space="preserve"><value>Заказы инфраструктуры</value></data>
+  <data name="UseCase1Description" xml:space="preserve"><value>Используйте оплату монетой для подходящих заказов на вычисления и хостинг.</value></data>
+  <data name="UseCase2Title" xml:space="preserve"><value>Поддержка подписок</value></data>
+  <data name="UseCase2Description" xml:space="preserve"><value>Готовый к будущему токен-поток для регулярных облачных сервисов.</value></data>
+  <data name="UseCase3Title" xml:space="preserve"><value>Партнерская экосистема</value></data>
+  <data name="UseCase3Description" xml:space="preserve"><value>Полезность в предложениях и кампаниях, связанных с CloudCity.</value></data>
+  <data name="FaqTitle" xml:space="preserve"><value>FAQ</value></data>
+  <data name="Faq1Question" xml:space="preserve"><value>Что такое CloudCity Coin?</value></data>
+  <data name="Faq1Answer" xml:space="preserve"><value>Цифровой платежный актив, созданный для полезности в экосистеме CloudCity.</value></data>
+  <data name="Faq2Question" xml:space="preserve"><value>Где его купить?</value></data>
+  <data name="Faq2Answer" xml:space="preserve"><value>На официальной странице Pump.fun по ссылке выше.</value></data>
+  <data name="Faq3Question" xml:space="preserve"><value>Нужен ли Phantom?</value></data>
+  <data name="Faq3Answer" xml:space="preserve"><value>Подойдет любой совместимый с Solana кошелек; Phantom — популярный вариант.</value></data>
+  <data name="FinalCtaTitle" xml:space="preserve"><value>Присоединяйтесь к экосистеме CloudCity Coin</value></data>
+  <data name="FinalCtaDescription" xml:space="preserve"><value>Войдите в премиальную среду cloud + crypto для digital-first платежей.</value></data>
+  <data name="RiskDisclaimer" xml:space="preserve"><value>Предупреждение о рисках: цифровые активы волатильны. Всегда проводите собственное исследование перед покупкой.</value></data>
+  <data name="FinalPrimaryCta" xml:space="preserve"><value>Buy CloudCity Coin</value></data>
+  <data name="FinalSecondaryCta" xml:space="preserve"><value>Связаться с CloudCity</value></data>
+  <data name="SEOTitle" xml:space="preserve"><value>CloudCity Coin - CloudCityCenter</value></data>
+  <data name="SEODescription" xml:space="preserve"><value>CloudCity Coin — цифровой платежный актив в экосистеме CloudCity с применением в отдельных инфраструктурных и облачных сервисах.</value></data>
+  <data name="SEOKeywords" xml:space="preserve"><value>CloudCity Coin, криптовалюта CloudCity, монета Solana, облачный платежный актив</value></data>
+</root>

--- a/CloudCityCenter/Resources/Views/Coin/Index.uk.resx
+++ b/CloudCityCenter/Resources/Views/Coin/Index.uk.resx
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root>
+  <data name="HeroBadge" xml:space="preserve"><value>Екосистема CloudCity</value></data>
+  <data name="HeroTitle" xml:space="preserve"><value>CloudCity Coin</value></data>
+  <data name="HeroSubtitle" xml:space="preserve"><value>Цифровий платіжний актив для екосистеми CloudCity</value></data>
+  <data name="HeroDescription" xml:space="preserve"><value>CloudCity Coin поєднує Web3-платежі з практичними хмарними інфраструктурними сервісами, допомагаючи клієнтам працювати з криптоактивами та обчислювальними ресурсами в єдиній сучасній екосистемі.</value></data>
+  <data name="HeroPrimaryCta" xml:space="preserve"><value>Купити CloudCity Coin</value></data>
+  <data name="HeroSecondaryCta" xml:space="preserve"><value>Як купити</value></data>
+  <data name="WhyTitle" xml:space="preserve"><value>Чому CloudCity Coin</value></data>
+  <data name="WhyCard1Title" xml:space="preserve"><value>Швидкі платежі</value></data>
+  <data name="WhyCard1Description" xml:space="preserve"><value>Швидкі транзакції Solana для сучасної хмарної комерції.</value></data>
+  <data name="WhyCard2Title" xml:space="preserve"><value>Нативно для екосистеми</value></data>
+  <data name="WhyCard2Description" xml:space="preserve"><value>Узгоджено з розвитком інфраструктури та сервісів CloudCity.</value></data>
+  <data name="WhyCard3Title" xml:space="preserve"><value>Безпечний процес</value></data>
+  <data name="WhyCard3Description" xml:space="preserve"><value>Транзакції з підписом гаманця та прозорі записи в блокчейні.</value></data>
+  <data name="EcosystemTitle" xml:space="preserve"><value>Корисність у сервісній екосистемі</value></data>
+  <data name="ServiceCard1Title" xml:space="preserve"><value>VPS</value></data>
+  <data name="ServiceCard1Description" xml:space="preserve"><value>Обчислювальні інстанси для масштабованих навантажень.</value></data>
+  <data name="ServiceCard2Title" xml:space="preserve"><value>VDI</value></data>
+  <data name="ServiceCard2Description" xml:space="preserve"><value>Хмарні робочі столи для розподілених команд.</value></data>
+  <data name="ServiceCard3Title" xml:space="preserve"><value>Windows Server</value></data>
+  <data name="ServiceCard3Description" xml:space="preserve"><value>Керовані шари інфраструктури Windows.</value></data>
+  <data name="ServiceCard4Title" xml:space="preserve"><value>VPN</value></data>
+  <data name="ServiceCard4Description" xml:space="preserve"><value>Безпечне приватне мережеве тунелювання.</value></data>
+  <data name="ServiceCard5Title" xml:space="preserve"><value>Web Hosting</value></data>
+  <data name="ServiceCard5Description" xml:space="preserve"><value>Надійний вебхостинг із сучасними стек-опціями.</value></data>
+  <data name="ServiceCard6Title" xml:space="preserve"><value>Security</value></data>
+  <data name="ServiceCard6Description" xml:space="preserve"><value>Архітектура та моніторинг із пріоритетом захисту.</value></data>
+  <data name="HowToBuyTitle" xml:space="preserve"><value>Як купити</value></data>
+  <data name="Step1Title" xml:space="preserve"><value>Встановіть Phantom Wallet</value></data>
+  <data name="Step1Description" xml:space="preserve"><value>Встановіть і безпечно створіть гаманець.</value></data>
+  <data name="Step2Title" xml:space="preserve"><value>Додайте SOL</value></data>
+  <data name="Step2Description" xml:space="preserve"><value>Поповніть гаманець SOL для купівлі та мережевих комісій.</value></data>
+  <data name="Step3Title" xml:space="preserve"><value>Відкрийте сторінку Pump.fun</value></data>
+  <data name="Step3LinkText" xml:space="preserve"><value>Офіційне посилання для купівлі CloudCity Coin</value></data>
+  <data name="Step4Title" xml:space="preserve"><value>Підключіть гаманець</value></data>
+  <data name="Step4Description" xml:space="preserve"><value>Підтвердьте підключення гаманця в Pump.fun.</value></data>
+  <data name="Step5Title" xml:space="preserve"><value>Купіть монету</value></data>
+  <data name="Step5Description" xml:space="preserve"><value>Оберіть суму та підтвердьте транзакцію.</value></data>
+  <data name="Step6Title" xml:space="preserve"><value>Зберігайте у гаманці</value></data>
+  <data name="Step6Description" xml:space="preserve"><value>Токени залишаються видимими та під вашим контролем у гаманці.</value></data>
+  <data name="UseCasesTitle" xml:space="preserve"><value>Сценарії оплати</value></data>
+  <data name="UseCase1Title" xml:space="preserve"><value>Інфраструктурні замовлення</value></data>
+  <data name="UseCase1Description" xml:space="preserve"><value>Використовуйте оплату монетою для відповідних замовлень на обчислення або хостинг.</value></data>
+  <data name="UseCase2Title" xml:space="preserve"><value>Підтримка підписок</value></data>
+  <data name="UseCase2Description" xml:space="preserve"><value>Готовий до майбутнього токен-флоу для регулярних хмарних сервісів.</value></data>
+  <data name="UseCase3Title" xml:space="preserve"><value>Партнерська екосистема</value></data>
+  <data name="UseCase3Description" xml:space="preserve"><value>Корисність у пропозиціях і кампаніях, пов’язаних із CloudCity.</value></data>
+  <data name="FaqTitle" xml:space="preserve"><value>FAQ</value></data>
+  <data name="Faq1Question" xml:space="preserve"><value>Що таке CloudCity Coin?</value></data>
+  <data name="Faq1Answer" xml:space="preserve"><value>Цифровий платіжний актив, створений для корисності в екосистемі CloudCity.</value></data>
+  <data name="Faq2Question" xml:space="preserve"><value>Де його купити?</value></data>
+  <data name="Faq2Answer" xml:space="preserve"><value>На офіційній сторінці Pump.fun за посиланням вище.</value></data>
+  <data name="Faq3Question" xml:space="preserve"><value>Чи потрібен Phantom?</value></data>
+  <data name="Faq3Answer" xml:space="preserve"><value>Підійде будь-який сумісний із Solana гаманець; Phantom — поширений варіант.</value></data>
+  <data name="FinalCtaTitle" xml:space="preserve"><value>Приєднуйтесь до екосистеми CloudCity Coin</value></data>
+  <data name="FinalCtaDescription" xml:space="preserve"><value>Увійдіть у преміальне середовище cloud + crypto для digital-first платежів.</value></data>
+  <data name="RiskDisclaimer" xml:space="preserve"><value>Попередження про ризики: цифрові активи волатильні. Завжди проводьте власне дослідження перед купівлею.</value></data>
+  <data name="FinalPrimaryCta" xml:space="preserve"><value>Buy CloudCity Coin</value></data>
+  <data name="FinalSecondaryCta" xml:space="preserve"><value>Зв’язатися з CloudCity</value></data>
+  <data name="SEOTitle" xml:space="preserve"><value>CloudCity Coin - CloudCityCenter</value></data>
+  <data name="SEODescription" xml:space="preserve"><value>CloudCity Coin — цифровий платіжний актив в екосистемі CloudCity з корисністю в окремих інфраструктурних і хмарних сервісах.</value></data>
+  <data name="SEOKeywords" xml:space="preserve"><value>CloudCity Coin, криптовалюта CloudCity, монета Solana, хмарний платіжний актив</value></data>
+</root>

--- a/CloudCityCenter/Views/Coin/Index.cshtml
+++ b/CloudCityCenter/Views/Coin/Index.cshtml
@@ -10,13 +10,13 @@
     <section class="coin-hero glass-panel">
         <div class="coin-hero-grid">
             <div class="coin-hero-content">
-                <p class="coin-kicker"><i class="bi bi-stars"></i> CloudCity Ecosystem</p>
-                <h1>CloudCity Coin</h1>
-                <p class="coin-subtitle">Digital payment asset for the CloudCity ecosystem</p>
-                <p class="coin-description">CloudCity Coin connects Web3-native payments with practical cloud infrastructure services, helping clients move between crypto and compute in one modern ecosystem.</p>
+                <p class="coin-kicker"><i class="bi bi-stars"></i> @Localizer["HeroBadge"]</p>
+                <h1>@Localizer["HeroTitle"]</h1>
+                <p class="coin-subtitle">@Localizer["HeroSubtitle"]</p>
+                <p class="coin-description">@Localizer["HeroDescription"]</p>
                 <div class="coin-hero-actions">
-                    <a class="btn coin-btn coin-btn-primary" href="@coinUrl" target="_blank" rel="noopener noreferrer">Buy CloudCity Coin</a>
-                    <a class="btn coin-btn coin-btn-ghost" href="#how-to-buy">How to Buy</a>
+                    <a class="btn coin-btn coin-btn-primary" href="@coinUrl" target="_blank" rel="noopener noreferrer">@Localizer["HeroPrimaryCta"]</a>
+                    <a class="btn coin-btn coin-btn-ghost" href="#how-to-buy">@Localizer["HeroSecondaryCta"]</a>
                 </div>
             </div>
             <div class="coin-hero-media" aria-hidden="true">
@@ -45,57 +45,58 @@
     </section>
 
     <section class="coin-section">
-        <h2>Why CloudCity Coin</h2>
+        <h2>@Localizer["WhyTitle"]</h2>
         <div class="coin-grid coin-value-grid">
-            <article class="coin-card"><i class="bi bi-lightning-charge-fill"></i><h3>Fast payments</h3><p>Speed-first Solana transactions for modern cloud commerce.</p></article>
-            <article class="coin-card"><i class="bi bi-diagram-3-fill"></i><h3>Ecosystem-native</h3><p>Aligned with CloudCity infrastructure and service growth.</p></article>
-            <article class="coin-card"><i class="bi bi-shield-check"></i><h3>Secure flow</h3><p>Wallet-signature transactions and transparent on-chain records.</p></article>
+            <article class="coin-card"><i class="bi bi-lightning-charge-fill"></i><h3>@Localizer["WhyCard1Title"]</h3><p>@Localizer["WhyCard1Description"]</p></article>
+            <article class="coin-card"><i class="bi bi-diagram-3-fill"></i><h3>@Localizer["WhyCard2Title"]</h3><p>@Localizer["WhyCard2Description"]</p></article>
+            <article class="coin-card"><i class="bi bi-shield-check"></i><h3>@Localizer["WhyCard3Title"]</h3><p>@Localizer["WhyCard3Description"]</p></article>
         </div>
     </section>
 
     <section class="coin-section">
-        <h2>Service Ecosystem Utility</h2>
+        <h2>@Localizer["EcosystemTitle"]</h2>
         <div class="coin-grid coin-services-grid">
-            <article class="coin-card"><i class="bi bi-hdd-network"></i><h3>VPS</h3><p>Compute instances for scalable workloads.</p></article><article class="coin-card"><i class="bi bi-display"></i><h3>VDI</h3><p>Cloud desktops for distributed teams.</p></article><article class="coin-card"><i class="bi bi-windows"></i><h3>Windows Server</h3><p>Managed Windows infrastructure layers.</p></article><article class="coin-card"><i class="bi bi-shield-lock"></i><h3>VPN</h3><p>Secure private network tunneling.</p></article><article class="coin-card"><i class="bi bi-globe2"></i><h3>Web Hosting</h3><p>Reliable web hosting with modern stack options.</p></article><article class="coin-card"><i class="bi bi-fingerprint"></i><h3>Security</h3><p>Protection-first architecture and monitoring.</p></article>
+            <article class="coin-card"><i class="bi bi-hdd-network"></i><h3>@Localizer["ServiceCard1Title"]</h3><p>@Localizer["ServiceCard1Description"]</p></article><article class="coin-card"><i class="bi bi-display"></i><h3>@Localizer["ServiceCard2Title"]</h3><p>@Localizer["ServiceCard2Description"]</p></article><article class="coin-card"><i class="bi bi-windows"></i><h3>@Localizer["ServiceCard3Title"]</h3><p>@Localizer["ServiceCard3Description"]</p></article><article class="coin-card"><i class="bi bi-shield-lock"></i><h3>@Localizer["ServiceCard4Title"]</h3><p>@Localizer["ServiceCard4Description"]</p></article><article class="coin-card"><i class="bi bi-globe2"></i><h3>@Localizer["ServiceCard5Title"]</h3><p>@Localizer["ServiceCard5Description"]</p></article><article class="coin-card"><i class="bi bi-fingerprint"></i><h3>@Localizer["ServiceCard6Title"]</h3><p>@Localizer["ServiceCard6Description"]</p></article>
         </div>
     </section>
 
     <section id="how-to-buy" class="coin-section">
-        <h2>How to Buy</h2>
+        <h2>@Localizer["HowToBuyTitle"]</h2>
         <div class="coin-timeline">
-            <article class="timeline-item"><span>01</span><div><h3><i class="bi bi-phone"></i> Install Phantom Wallet</h3><p>Install and create your wallet securely.</p></div></article>
-            <article class="timeline-item"><span>02</span><div><h3><i class="bi bi-currency-exchange"></i> Add SOL</h3><p>Fund wallet with SOL for purchase + network fees.</p></div></article>
-            <article class="timeline-item"><span>03</span><div><h3><i class="bi bi-box-arrow-up-right"></i> Open Pump.fun page</h3><p><a href="@coinUrl" target="_blank" rel="noopener noreferrer">Official CloudCity Coin buy link</a>.</p></div></article>
-            <article class="timeline-item"><span>04</span><div><h3><i class="bi bi-wallet2"></i> Connect wallet</h3><p>Authorize wallet connection in Pump.fun.</p></div></article>
-            <article class="timeline-item"><span>05</span><div><h3><i class="bi bi-bag-check"></i> Buy Coin</h3><p>Select amount and confirm transaction.</p></div></article>
-            <article class="timeline-item"><span>06</span><div><h3><i class="bi bi-safe2"></i> Hold inside wallet</h3><p>Tokens remain visible and controlled in your wallet.</p></div></article>
+            <article class="timeline-item"><span>01</span><div><h3><i class="bi bi-phone"></i> @Localizer["Step1Title"]</h3><p>@Localizer["Step1Description"]</p></div></article>
+            <article class="timeline-item"><span>02</span><div><h3><i class="bi bi-currency-exchange"></i> @Localizer["Step2Title"]</h3><p>@Localizer["Step2Description"]</p></div></article>
+            <article class="timeline-item"><span>03</span><div><h3><i class="bi bi-box-arrow-up-right"></i> @Localizer["Step3Title"]</h3><p><a href="@coinUrl" target="_blank" rel="noopener noreferrer">@Localizer["Step3LinkText"]</a>.</p></div></article>
+            <article class="timeline-item"><span>04</span><div><h3><i class="bi bi-wallet2"></i> @Localizer["Step4Title"]</h3><p>@Localizer["Step4Description"]</p></div></article>
+            <article class="timeline-item"><span>05</span><div><h3><i class="bi bi-bag-check"></i> @Localizer["Step5Title"]</h3><p>@Localizer["Step5Description"]</p></div></article>
+            <article class="timeline-item"><span>06</span><div><h3><i class="bi bi-safe2"></i> @Localizer["Step6Title"]</h3><p>@Localizer["Step6Description"]</p></div></article>
         </div>
     </section>
 
     <section class="coin-section">
-        <h2>Payment Use Cases</h2>
+        <h2>@Localizer["UseCasesTitle"]</h2>
         <div class="coin-grid">
-            <article class="coin-card"><h3>Infrastructure orders</h3><p>Use coin-based payments for eligible compute or hosting orders.</p></article>
-            <article class="coin-card"><h3>Subscription support</h3><p>Future-ready token flow for recurring cloud services.</p></article>
-            <article class="coin-card"><h3>Partner ecosystem</h3><p>Utility across CloudCity-aligned offerings and campaigns.</p></article>
+            <article class="coin-card"><h3>@Localizer["UseCase1Title"]</h3><p>@Localizer["UseCase1Description"]</p></article>
+            <article class="coin-card"><h3>@Localizer["UseCase2Title"]</h3><p>@Localizer["UseCase2Description"]</p></article>
+            <article class="coin-card"><h3>@Localizer["UseCase3Title"]</h3><p>@Localizer["UseCase3Description"]</p></article>
         </div>
     </section>
 
     <section class="coin-section">
-        <h2>FAQ</h2>
+        <h2>@Localizer["FaqTitle"]</h2>
         <div class="coin-faq">
-            <details class="coin-card"><summary>What is CloudCity Coin?</summary><p>A digital payment asset designed for CloudCity ecosystem utility.</p></details>
-            <details class="coin-card"><summary>Where do I buy it?</summary><p>On the official Pump.fun page linked above.</p></details>
-            <details class="coin-card"><summary>Do I need Phantom?</summary><p>You need any Solana-compatible wallet; Phantom is common.</p></details>
+            <details class="coin-card"><summary>@Localizer["Faq1Question"]</summary><p>@Localizer["Faq1Answer"]</p></details>
+            <details class="coin-card"><summary>@Localizer["Faq2Question"]</summary><p>@Localizer["Faq2Answer"]</p></details>
+            <details class="coin-card"><summary>@Localizer["Faq3Question"]</summary><p>@Localizer["Faq3Answer"]</p></details>
         </div>
     </section>
 
     <section class="coin-section coin-final-cta glass-panel">
-        <h2>Join the CloudCity Coin ecosystem</h2>
-        <p>Enter a premium cloud + crypto environment built for digital-first payments.</p>
+        <h2>@Localizer["FinalCtaTitle"]</h2>
+        <p>@Localizer["FinalCtaDescription"]</p>
+        <p class="coin-disclaimer">@Localizer["RiskDisclaimer"]</p>
         <div class="coin-hero-actions">
-            <a class="btn coin-btn coin-btn-primary" href="@coinUrl" target="_blank" rel="noopener noreferrer">Buy CloudCity Coin</a>
-            <a class="btn coin-btn coin-btn-ghost" asp-controller="Contact" asp-action="Index">Contact CloudCity</a>
+            <a class="btn coin-btn coin-btn-primary" href="@coinUrl" target="_blank" rel="noopener noreferrer">@Localizer["FinalPrimaryCta"]</a>
+            <a class="btn coin-btn coin-btn-ghost" asp-controller="Contact" asp-action="Index">@Localizer["FinalSecondaryCta"]</a>
         </div>
     </section>
 </div>


### PR DESCRIPTION
### Motivation
- Enable multilingual support on the CloudCity Coin landing page using the project’s existing localization pipeline so the page follows the site-wide language switcher behavior.
- Move all visible page copy (hero, CTAs, sections, cards, How-to-Buy steps, FAQ, disclaimer, final CTA) out of the Razor view and into resource files to avoid hardcoded text.
- Provide English, Russian and Ukrainian translations with an English base fallback and localized SEO metadata for better international SEO.

### Description
- Replaced hardcoded strings in `Views/Coin/Index.cshtml` with `@Localizer["Key"]` lookups for every visible text element while keeping the CSS/SVG/layout unchanged.
- Added resource files `Resources/Views/Coin/Index.resx` (default English), `Resources/Views/Coin/Index.ru.resx` (Russian) and `Resources/Views/Coin/Index.uk.resx` (Ukrainian) containing all page copy and SEO keys (`SEOTitle`, `SEODescription`, `SEOKeywords`).
- Updated `CoinController` to use `IStringLocalizerFactory` (creating `Views.Coin.Index` localizer) and set localized SEO metadata into `ViewData["Title"]`, `ViewData["Description"]` and `ViewData["Keywords"]` so the shared layout will emit localized meta tags.
- Continued to rely on the existing project localization setup (`AddViewLocalization`, request culture providers and `LanguageController`) and the base `.resx` for English fallback.

### Testing
- Attempted to run `dotnet build CloudCityCenter/CloudCityCenter.csproj` to validate compilation, but the build could not be executed in this environment because the `dotnet` SDK is not installed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae952f624832b9967bb2140dd1a39)