### PR TITLE
Add CloudCity Coin translations for PL / FR / DE / ES

### DIFF
--- a/CloudCityCenter/Resources/Views/Coin/Index.de.resx
+++ b/CloudCityCenter/Resources/Views/Coin/Index.de.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="HeroBadge" xml:space="preserve"><value>CloudCity-Ökosystem</value></data>
+  <data name="HeroTitle" xml:space="preserve"><value>CloudCity Coin</value></data>
+  <data name="HeroSubtitle" xml:space="preserve"><value>Digitales Zahlungs-Asset für das CloudCity-Ökosystem</value></data>
+  <data name="HeroDescription" xml:space="preserve"><value>CloudCity Coin verbindet Web3-native Zahlungen mit praktischen Cloud-Infrastruktur-Services und hilft Kunden, in einem modernen Ökosystem zwischen Krypto und Rechenleistung zu wechseln.</value></data>
+  <data name="HeroPrimaryCta" xml:space="preserve"><value>CloudCity Coin kaufen</value></data>
+  <data name="HeroSecondaryCta" xml:space="preserve"><value>So kaufst du</value></data>
+  <data name="WhyTitle" xml:space="preserve"><value>Warum CloudCity Coin</value></data>
+  <data name="WhyCard1Title" xml:space="preserve"><value>Schnelle Zahlungen</value></data>
+  <data name="WhyCard1Description" xml:space="preserve"><value>Schnelle Solana-Transaktionen für modernen Cloud-Commerce.</value></data>
+  <data name="WhyCard2Title" xml:space="preserve"><value>Ökosystem-nativ</value></data>
+  <data name="WhyCard2Description" xml:space="preserve"><value>Abgestimmt auf das Wachstum von CloudCity-Infrastruktur und -Services.</value></data>
+  <data name="WhyCard3Title" xml:space="preserve"><value>Sicherer Ablauf</value></data>
+  <data name="WhyCard3Description" xml:space="preserve"><value>Wallet-signierte Transaktionen und transparente On-Chain-Aufzeichnungen.</value></data>
+  <data name="EcosystemTitle" xml:space="preserve"><value>Nutzen im Service-Ökosystem</value></data>
+  <data name="ServiceCard1Title" xml:space="preserve"><value>VPS</value></data>
+  <data name="ServiceCard1Description" xml:space="preserve"><value>Compute-Instanzen für skalierbare Workloads.</value></data>
+  <data name="ServiceCard2Title" xml:space="preserve"><value>VDI</value></data>
+  <data name="ServiceCard2Description" xml:space="preserve"><value>Cloud-Desktops für verteilte Teams.</value></data>
+  <data name="ServiceCard3Title" xml:space="preserve"><value>Windows Server</value></data>
+  <data name="ServiceCard3Description" xml:space="preserve"><value>Verwaltete Windows-Infrastruktur-Ebenen.</value></data>
+  <data name="ServiceCard4Title" xml:space="preserve"><value>VPN</value></data>
+  <data name="ServiceCard4Description" xml:space="preserve"><value>Sicheres privates Netzwerk-Tunneling.</value></data>
+  <data name="ServiceCard5Title" xml:space="preserve"><value>Webhosting</value></data>
+  <data name="ServiceCard5Description" xml:space="preserve"><value>Zuverlässiges Webhosting mit modernen Stack-Optionen.</value></data>
+  <data name="ServiceCard6Title" xml:space="preserve"><value>Sicherheit</value></data>
+  <data name="ServiceCard6Description" xml:space="preserve"><value>Schutzorientierte Architektur und Überwachung.</value></data>
+  <data name="HowToBuyTitle" xml:space="preserve"><value>So kaufst du</value></data>
+  <data name="Step1Title" xml:space="preserve"><value>Phantom Wallet installieren</value></data>
+  <data name="Step1Description" xml:space="preserve"><value>Installiere und erstelle deine Wallet sicher.</value></data>
+  <data name="Step2Title" xml:space="preserve"><value>SOL hinzufügen</value></data>
+  <data name="Step2Description" xml:space="preserve"><value>Lade die Wallet mit SOL für Kauf + Netzwerkgebühren auf.</value></data>
+  <data name="Step3Title" xml:space="preserve"><value>Pump.fun-Seite öffnen</value></data>
+  <data name="Step3LinkText" xml:space="preserve"><value>Offizieller CloudCity Coin-Kauflink</value></data>
+  <data name="Step4Title" xml:space="preserve"><value>Wallet verbinden</value></data>
+  <data name="Step4Description" xml:space="preserve"><value>Autorisieren die Wallet-Verbindung in Pump.fun.</value></data>
+  <data name="Step5Title" xml:space="preserve"><value>Coin kaufen</value></data>
+  <data name="Step5Description" xml:space="preserve"><value>Betrag auswählen und Transaktion bestätigen.</value></data>
+  <data name="Step6Title" xml:space="preserve"><value>In der Wallet halten</value></data>
+  <data name="Step6Description" xml:space="preserve"><value>Tokens bleiben sichtbar und unter deiner Kontrolle in deiner Wallet.</value></data>
+  <data name="UseCasesTitle" xml:space="preserve"><value>Zahlungsanwendungsfälle</value></data>
+  <data name="UseCase1Title" xml:space="preserve"><value>Infrastruktur-Bestellungen</value></data>
+  <data name="UseCase1Description" xml:space="preserve"><value>Nutze Coin-Zahlungen für berechtigte Compute- oder Hosting-Bestellungen.</value></data>
+  <data name="UseCase2Title" xml:space="preserve"><value>Abo-Unterstützung</value></data>
+  <data name="UseCase2Description" xml:space="preserve"><value>Zukunftsfähiger Token-Flow für wiederkehrende Cloud-Services.</value></data>
+  <data name="UseCase3Title" xml:space="preserve"><value>Partner-Ökosystem</value></data>
+  <data name="UseCase3Description" xml:space="preserve"><value>Nutzen in CloudCity-nahen Angeboten und Kampagnen.</value></data>
+  <data name="FaqTitle" xml:space="preserve"><value>FAQ</value></data>
+  <data name="Faq1Question" xml:space="preserve"><value>Was ist CloudCity Coin?</value></data>
+  <data name="Faq1Answer" xml:space="preserve"><value>Ein digitales Zahlungs-Asset für die Nutzung im CloudCity-Ökosystem.</value></data>
+  <data name="Faq2Question" xml:space="preserve"><value>Wo kann ich ihn kaufen?</value></data>
+  <data name="Faq2Answer" xml:space="preserve"><value>Auf der oben verlinkten offiziellen Pump.fun-Seite.</value></data>
+  <data name="Faq3Question" xml:space="preserve"><value>Brauche ich Phantom?</value></data>
+  <data name="Faq3Answer" xml:space="preserve"><value>Du brauchst eine Solana-kompatible Wallet; Phantom ist weit verbreitet.</value></data>
+  <data name="FinalCtaTitle" xml:space="preserve"><value>Tritt dem CloudCity Coin-Ökosystem bei</value></data>
+  <data name="FinalCtaDescription" xml:space="preserve"><value>Betritt eine Premium-Cloud- + Krypto-Umgebung für digital-first Zahlungen.</value></data>
+  <data name="RiskDisclaimer" xml:space="preserve"><value>Risikohinweis: Digitale Assets sind volatil. Recherchiere immer selbst vor einem Kauf.</value></data>
+  <data name="FinalPrimaryCta" xml:space="preserve"><value>CloudCity Coin kaufen</value></data>
+  <data name="FinalSecondaryCta" xml:space="preserve"><value>CloudCity kontaktieren</value></data>
+  <data name="SEOTitle" xml:space="preserve"><value>CloudCity Coin - CloudCityCenter</value></data>
+  <data name="SEODescription" xml:space="preserve"><value>CloudCity Coin ist ein digitales Zahlungs-Asset im CloudCity-Ökosystem mit Nutzen in ausgewählten Infrastruktur- und Cloud-Services.</value></data>
+  <data name="SEOKeywords" xml:space="preserve"><value>CloudCity Coin, CloudCity Krypto, Solana Coin, Cloud-Zahlungs-Asset</value></data>
+</root>

--- a/CloudCityCenter/Resources/Views/Coin/Index.es.resx
+++ b/CloudCityCenter/Resources/Views/Coin/Index.es.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="HeroBadge" xml:space="preserve"><value>Ecosistema CloudCity</value></data>
+  <data name="HeroTitle" xml:space="preserve"><value>CloudCity Coin</value></data>
+  <data name="HeroSubtitle" xml:space="preserve"><value>Activo de pago digital para el ecosistema CloudCity</value></data>
+  <data name="HeroDescription" xml:space="preserve"><value>CloudCity Coin conecta pagos nativos de Web3 con servicios prácticos de infraestructura en la nube, ayudando a los clientes a moverse entre cripto y cómputo en un único ecosistema moderno.</value></data>
+  <data name="HeroPrimaryCta" xml:space="preserve"><value>Comprar CloudCity Coin</value></data>
+  <data name="HeroSecondaryCta" xml:space="preserve"><value>Cómo comprar</value></data>
+  <data name="WhyTitle" xml:space="preserve"><value>Por qué CloudCity Coin</value></data>
+  <data name="WhyCard1Title" xml:space="preserve"><value>Pagos rápidos</value></data>
+  <data name="WhyCard1Description" xml:space="preserve"><value>Transacciones Solana rápidas para el comercio cloud moderno.</value></data>
+  <data name="WhyCard2Title" xml:space="preserve"><value>Nativo del ecosistema</value></data>
+  <data name="WhyCard2Description" xml:space="preserve"><value>Alineado con el crecimiento de la infraestructura y servicios de CloudCity.</value></data>
+  <data name="WhyCard3Title" xml:space="preserve"><value>Flujo seguro</value></data>
+  <data name="WhyCard3Description" xml:space="preserve"><value>Transacciones firmadas con wallet y registros on-chain transparentes.</value></data>
+  <data name="EcosystemTitle" xml:space="preserve"><value>Utilidad en el ecosistema de servicios</value></data>
+  <data name="ServiceCard1Title" xml:space="preserve"><value>VPS</value></data>
+  <data name="ServiceCard1Description" xml:space="preserve"><value>Instancias de cómputo para cargas de trabajo escalables.</value></data>
+  <data name="ServiceCard2Title" xml:space="preserve"><value>VDI</value></data>
+  <data name="ServiceCard2Description" xml:space="preserve"><value>Escritorios en la nube para equipos distribuidos.</value></data>
+  <data name="ServiceCard3Title" xml:space="preserve"><value>Windows Server</value></data>
+  <data name="ServiceCard3Description" xml:space="preserve"><value>Capas de infraestructura Windows administradas.</value></data>
+  <data name="ServiceCard4Title" xml:space="preserve"><value>VPN</value></data>
+  <data name="ServiceCard4Description" xml:space="preserve"><value>Tunelización de red privada segura.</value></data>
+  <data name="ServiceCard5Title" xml:space="preserve"><value>Hosting web</value></data>
+  <data name="ServiceCard5Description" xml:space="preserve"><value>Hosting web confiable con opciones de stack modernas.</value></data>
+  <data name="ServiceCard6Title" xml:space="preserve"><value>Seguridad</value></data>
+  <data name="ServiceCard6Description" xml:space="preserve"><value>Arquitectura y monitoreo con la protección como prioridad.</value></data>
+  <data name="HowToBuyTitle" xml:space="preserve"><value>Cómo comprar</value></data>
+  <data name="Step1Title" xml:space="preserve"><value>Instalar Phantom Wallet</value></data>
+  <data name="Step1Description" xml:space="preserve"><value>Instala y crea tu wallet de forma segura.</value></data>
+  <data name="Step2Title" xml:space="preserve"><value>Agregar SOL</value></data>
+  <data name="Step2Description" xml:space="preserve"><value>Recarga la wallet con SOL para compra + comisiones de red.</value></data>
+  <data name="Step3Title" xml:space="preserve"><value>Abrir la página de Pump.fun</value></data>
+  <data name="Step3LinkText" xml:space="preserve"><value>Enlace oficial de compra de CloudCity Coin</value></data>
+  <data name="Step4Title" xml:space="preserve"><value>Conectar wallet</value></data>
+  <data name="Step4Description" xml:space="preserve"><value>Autoriza la conexión de la wallet en Pump.fun.</value></data>
+  <data name="Step5Title" xml:space="preserve"><value>Comprar la moneda</value></data>
+  <data name="Step5Description" xml:space="preserve"><value>Selecciona el monto y confirma la transacción.</value></data>
+  <data name="Step6Title" xml:space="preserve"><value>Mantener en la wallet</value></data>
+  <data name="Step6Description" xml:space="preserve"><value>Los tokens permanecen visibles y bajo tu control en tu wallet.</value></data>
+  <data name="UseCasesTitle" xml:space="preserve"><value>Casos de uso de pago</value></data>
+  <data name="UseCase1Title" xml:space="preserve"><value>Pedidos de infraestructura</value></data>
+  <data name="UseCase1Description" xml:space="preserve"><value>Usa pagos con coin para pedidos elegibles de cómputo u hosting.</value></data>
+  <data name="UseCase2Title" xml:space="preserve"><value>Soporte de suscripciones</value></data>
+  <data name="UseCase2Description" xml:space="preserve"><value>Flujo de tokens preparado para el futuro de servicios cloud recurrentes.</value></data>
+  <data name="UseCase3Title" xml:space="preserve"><value>Ecosistema de socios</value></data>
+  <data name="UseCase3Description" xml:space="preserve"><value>Utilidad en ofertas y campañas alineadas con CloudCity.</value></data>
+  <data name="FaqTitle" xml:space="preserve"><value>FAQ</value></data>
+  <data name="Faq1Question" xml:space="preserve"><value>¿Qué es CloudCity Coin?</value></data>
+  <data name="Faq1Answer" xml:space="preserve"><value>Un activo de pago digital diseñado para la utilidad del ecosistema CloudCity.</value></data>
+  <data name="Faq2Question" xml:space="preserve"><value>¿Dónde lo compro?</value></data>
+  <data name="Faq2Answer" xml:space="preserve"><value>En la página oficial de Pump.fun enlazada arriba.</value></data>
+  <data name="Faq3Question" xml:space="preserve"><value>¿Necesito Phantom?</value></data>
+  <data name="Faq3Answer" xml:space="preserve"><value>Necesitas cualquier wallet compatible con Solana; Phantom es una opción común.</value></data>
+  <data name="FinalCtaTitle" xml:space="preserve"><value>Únete al ecosistema CloudCity Coin</value></data>
+  <data name="FinalCtaDescription" xml:space="preserve"><value>Entra en un entorno premium de cloud + cripto diseñado para pagos digital-first.</value></data>
+  <data name="RiskDisclaimer" xml:space="preserve"><value>Aviso de riesgo: Los activos digitales son volátiles. Siempre investiga por tu cuenta antes de comprar.</value></data>
+  <data name="FinalPrimaryCta" xml:space="preserve"><value>Comprar CloudCity Coin</value></data>
+  <data name="FinalSecondaryCta" xml:space="preserve"><value>Contactar a CloudCity</value></data>
+  <data name="SEOTitle" xml:space="preserve"><value>CloudCity Coin - CloudCityCenter</value></data>
+  <data name="SEODescription" xml:space="preserve"><value>CloudCity Coin es un activo de pago digital en el ecosistema CloudCity, con utilidad en servicios seleccionados de infraestructura y nube.</value></data>
+  <data name="SEOKeywords" xml:space="preserve"><value>CloudCity Coin, cripto CloudCity, moneda Solana, activo de pago cloud</value></data>
+</root>

--- a/CloudCityCenter/Resources/Views/Coin/Index.fr.resx
+++ b/CloudCityCenter/Resources/Views/Coin/Index.fr.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="HeroBadge" xml:space="preserve"><value>Écosystème CloudCity</value></data>
+  <data name="HeroTitle" xml:space="preserve"><value>CloudCity Coin</value></data>
+  <data name="HeroSubtitle" xml:space="preserve"><value>Actif de paiement numérique pour l’écosystème CloudCity</value></data>
+  <data name="HeroDescription" xml:space="preserve"><value>CloudCity Coin relie les paiements natifs Web3 à des services d’infrastructure cloud pratiques, aidant les clients à passer de la crypto à la puissance de calcul dans un écosystème moderne unique.</value></data>
+  <data name="HeroPrimaryCta" xml:space="preserve"><value>Acheter CloudCity Coin</value></data>
+  <data name="HeroSecondaryCta" xml:space="preserve"><value>Comment acheter</value></data>
+  <data name="WhyTitle" xml:space="preserve"><value>Pourquoi CloudCity Coin</value></data>
+  <data name="WhyCard1Title" xml:space="preserve"><value>Paiements rapides</value></data>
+  <data name="WhyCard1Description" xml:space="preserve"><value>Transactions Solana rapides pour le commerce cloud moderne.</value></data>
+  <data name="WhyCard2Title" xml:space="preserve"><value>Natif de l’écosystème</value></data>
+  <data name="WhyCard2Description" xml:space="preserve"><value>Aligné avec la croissance de l’infrastructure et des services CloudCity.</value></data>
+  <data name="WhyCard3Title" xml:space="preserve"><value>Flux sécurisé</value></data>
+  <data name="WhyCard3Description" xml:space="preserve"><value>Transactions signées par portefeuille et enregistrements on-chain transparents.</value></data>
+  <data name="EcosystemTitle" xml:space="preserve"><value>Utilité dans l’écosystème de services</value></data>
+  <data name="ServiceCard1Title" xml:space="preserve"><value>VPS</value></data>
+  <data name="ServiceCard1Description" xml:space="preserve"><value>Instances de calcul pour des charges de travail évolutives.</value></data>
+  <data name="ServiceCard2Title" xml:space="preserve"><value>VDI</value></data>
+  <data name="ServiceCard2Description" xml:space="preserve"><value>Postes de travail cloud pour les équipes distribuées.</value></data>
+  <data name="ServiceCard3Title" xml:space="preserve"><value>Windows Server</value></data>
+  <data name="ServiceCard3Description" xml:space="preserve"><value>Couches d’infrastructure Windows gérées.</value></data>
+  <data name="ServiceCard4Title" xml:space="preserve"><value>VPN</value></data>
+  <data name="ServiceCard4Description" xml:space="preserve"><value>Tunnel réseau privé sécurisé.</value></data>
+  <data name="ServiceCard5Title" xml:space="preserve"><value>Hébergement Web</value></data>
+  <data name="ServiceCard5Description" xml:space="preserve"><value>Hébergement web fiable avec des options de stack modernes.</value></data>
+  <data name="ServiceCard6Title" xml:space="preserve"><value>Sécurité</value></data>
+  <data name="ServiceCard6Description" xml:space="preserve"><value>Architecture et supervision orientées protection avant tout.</value></data>
+  <data name="HowToBuyTitle" xml:space="preserve"><value>Comment acheter</value></data>
+  <data name="Step1Title" xml:space="preserve"><value>Installer Phantom Wallet</value></data>
+  <data name="Step1Description" xml:space="preserve"><value>Installez et créez votre portefeuille en toute sécurité.</value></data>
+  <data name="Step2Title" xml:space="preserve"><value>Ajouter SOL</value></data>
+  <data name="Step2Description" xml:space="preserve"><value>Approvisionnez votre portefeuille en SOL pour l’achat + les frais réseau.</value></data>
+  <data name="Step3Title" xml:space="preserve"><value>Ouvrir la page Pump.fun</value></data>
+  <data name="Step3LinkText" xml:space="preserve"><value>Lien officiel d’achat CloudCity Coin</value></data>
+  <data name="Step4Title" xml:space="preserve"><value>Connecter le portefeuille</value></data>
+  <data name="Step4Description" xml:space="preserve"><value>Autorisez la connexion du portefeuille dans Pump.fun.</value></data>
+  <data name="Step5Title" xml:space="preserve"><value>Acheter la pièce</value></data>
+  <data name="Step5Description" xml:space="preserve"><value>Sélectionnez le montant et confirmez la transaction.</value></data>
+  <data name="Step6Title" xml:space="preserve"><value>Conserver dans le portefeuille</value></data>
+  <data name="Step6Description" xml:space="preserve"><value>Les tokens restent visibles et sous votre contrôle dans votre portefeuille.</value></data>
+  <data name="UseCasesTitle" xml:space="preserve"><value>Cas d’usage des paiements</value></data>
+  <data name="UseCase1Title" xml:space="preserve"><value>Commandes d’infrastructure</value></data>
+  <data name="UseCase1Description" xml:space="preserve"><value>Utilisez les paiements en coin pour les commandes éligibles de calcul ou d’hébergement.</value></data>
+  <data name="UseCase2Title" xml:space="preserve"><value>Support des abonnements</value></data>
+  <data name="UseCase2Description" xml:space="preserve"><value>Flux de tokens prêt pour l’avenir des services cloud récurrents.</value></data>
+  <data name="UseCase3Title" xml:space="preserve"><value>Écosystème partenaire</value></data>
+  <data name="UseCase3Description" xml:space="preserve"><value>Utilité dans les offres et campagnes alignées CloudCity.</value></data>
+  <data name="FaqTitle" xml:space="preserve"><value>FAQ</value></data>
+  <data name="Faq1Question" xml:space="preserve"><value>Qu’est-ce que CloudCity Coin ?</value></data>
+  <data name="Faq1Answer" xml:space="preserve"><value>Un actif de paiement numérique conçu pour l’utilité de l’écosystème CloudCity.</value></data>
+  <data name="Faq2Question" xml:space="preserve"><value>Où puis-je l’acheter ?</value></data>
+  <data name="Faq2Answer" xml:space="preserve"><value>Sur la page officielle Pump.fun liée ci-dessus.</value></data>
+  <data name="Faq3Question" xml:space="preserve"><value>Ai-je besoin de Phantom ?</value></data>
+  <data name="Faq3Answer" xml:space="preserve"><value>Vous avez besoin de n’importe quel portefeuille compatible Solana ; Phantom est le plus courant.</value></data>
+  <data name="FinalCtaTitle" xml:space="preserve"><value>Rejoignez l’écosystème CloudCity Coin</value></data>
+  <data name="FinalCtaDescription" xml:space="preserve"><value>Entrez dans un environnement premium cloud + crypto conçu pour les paiements digital-first.</value></data>
+  <data name="RiskDisclaimer" xml:space="preserve"><value>Avertissement sur les risques : Les actifs numériques sont volatils. Faites toujours vos propres recherches avant tout achat.</value></data>
+  <data name="FinalPrimaryCta" xml:space="preserve"><value>Acheter CloudCity Coin</value></data>
+  <data name="FinalSecondaryCta" xml:space="preserve"><value>Contacter CloudCity</value></data>
+  <data name="SEOTitle" xml:space="preserve"><value>CloudCity Coin - CloudCityCenter</value></data>
+  <data name="SEODescription" xml:space="preserve"><value>CloudCity Coin est un actif de paiement numérique dans l’écosystème CloudCity, avec une utilité dans certains services d’infrastructure et cloud.</value></data>
+  <data name="SEOKeywords" xml:space="preserve"><value>CloudCity Coin, crypto CloudCity, pièce Solana, actif de paiement cloud</value></data>
+</root>

--- a/CloudCityCenter/Resources/Views/Coin/Index.pl.resx
+++ b/CloudCityCenter/Resources/Views/Coin/Index.pl.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="HeroBadge" xml:space="preserve"><value>Ekosystem CloudCity</value></data>
+  <data name="HeroTitle" xml:space="preserve"><value>CloudCity Coin</value></data>
+  <data name="HeroSubtitle" xml:space="preserve"><value>Cyfrowy aktyw płatniczy dla ekosystemu CloudCity</value></data>
+  <data name="HeroDescription" xml:space="preserve"><value>CloudCity Coin łączy natywne płatności Web3 z praktycznymi usługami infrastruktury chmurowej, pomagając klientom sprawnie łączyć krypto i moc obliczeniową w jednym nowoczesnym ekosystemie.</value></data>
+  <data name="HeroPrimaryCta" xml:space="preserve"><value>Kup CloudCity Coin</value></data>
+  <data name="HeroSecondaryCta" xml:space="preserve"><value>Jak kupić</value></data>
+  <data name="WhyTitle" xml:space="preserve"><value>Dlaczego CloudCity Coin</value></data>
+  <data name="WhyCard1Title" xml:space="preserve"><value>Szybkie płatności</value></data>
+  <data name="WhyCard1Description" xml:space="preserve"><value>Szybkie transakcje Solana dla nowoczesnego handlu usługami chmurowymi.</value></data>
+  <data name="WhyCard2Title" xml:space="preserve"><value>Natywny dla ekosystemu</value></data>
+  <data name="WhyCard2Description" xml:space="preserve"><value>Zgodny z rozwojem infrastruktury i usług CloudCity.</value></data>
+  <data name="WhyCard3Title" xml:space="preserve"><value>Bezpieczny przepływ</value></data>
+  <data name="WhyCard3Description" xml:space="preserve"><value>Transakcje podpisywane portfelem i przejrzyste zapisy on-chain.</value></data>
+  <data name="EcosystemTitle" xml:space="preserve"><value>Zastosowanie w ekosystemie usług</value></data>
+  <data name="ServiceCard1Title" xml:space="preserve"><value>VPS</value></data>
+  <data name="ServiceCard1Description" xml:space="preserve"><value>Instancje obliczeniowe dla skalowalnych obciążeń.</value></data>
+  <data name="ServiceCard2Title" xml:space="preserve"><value>VDI</value></data>
+  <data name="ServiceCard2Description" xml:space="preserve"><value>Pulpity chmurowe dla rozproszonych zespołów.</value></data>
+  <data name="ServiceCard3Title" xml:space="preserve"><value>Windows Server</value></data>
+  <data name="ServiceCard3Description" xml:space="preserve"><value>Zarządzane warstwy infrastruktury Windows.</value></data>
+  <data name="ServiceCard4Title" xml:space="preserve"><value>VPN</value></data>
+  <data name="ServiceCard4Description" xml:space="preserve"><value>Bezpieczne prywatne tunelowanie sieciowe.</value></data>
+  <data name="ServiceCard5Title" xml:space="preserve"><value>Hosting WWW</value></data>
+  <data name="ServiceCard5Description" xml:space="preserve"><value>Niezawodny hosting WWW z nowoczesnym stosem technologicznym.</value></data>
+  <data name="ServiceCard6Title" xml:space="preserve"><value>Bezpieczeństwo</value></data>
+  <data name="ServiceCard6Description" xml:space="preserve"><value>Architektura i monitoring stawiające bezpieczeństwo na pierwszym miejscu.</value></data>
+  <data name="HowToBuyTitle" xml:space="preserve"><value>Jak kupić</value></data>
+  <data name="Step1Title" xml:space="preserve"><value>Zainstaluj Phantom Wallet</value></data>
+  <data name="Step1Description" xml:space="preserve"><value>Zainstaluj i bezpiecznie utwórz swój portfel.</value></data>
+  <data name="Step2Title" xml:space="preserve"><value>Dodaj SOL</value></data>
+  <data name="Step2Description" xml:space="preserve"><value>Zasil portfel SOL na zakup + opłaty sieciowe.</value></data>
+  <data name="Step3Title" xml:space="preserve"><value>Otwórz stronę Pump.fun</value></data>
+  <data name="Step3LinkText" xml:space="preserve"><value>Oficjalny link zakupu CloudCity Coin</value></data>
+  <data name="Step4Title" xml:space="preserve"><value>Połącz portfel</value></data>
+  <data name="Step4Description" xml:space="preserve"><value>Autoryzuj połączenie portfela w Pump.fun.</value></data>
+  <data name="Step5Title" xml:space="preserve"><value>Kup monetę</value></data>
+  <data name="Step5Description" xml:space="preserve"><value>Wybierz kwotę i potwierdź transakcję.</value></data>
+  <data name="Step6Title" xml:space="preserve"><value>Przechowuj w portfelu</value></data>
+  <data name="Step6Description" xml:space="preserve"><value>Tokeny pozostają widoczne i pod Twoją kontrolą w portfelu.</value></data>
+  <data name="UseCasesTitle" xml:space="preserve"><value>Przypadki użycia płatności</value></data>
+  <data name="UseCase1Title" xml:space="preserve"><value>Zamówienia infrastruktury</value></data>
+  <data name="UseCase1Description" xml:space="preserve"><value>Używaj płatności monetą w kwalifikujących się zamówieniach na usługi obliczeniowe lub hostingowe.</value></data>
+  <data name="UseCase2Title" xml:space="preserve"><value>Obsługa subskrypcji</value></data>
+  <data name="UseCase2Description" xml:space="preserve"><value>Przyszłościowy przepływ tokenów dla cyklicznych usług chmurowych.</value></data>
+  <data name="UseCase3Title" xml:space="preserve"><value>Ekosystem partnerów</value></data>
+  <data name="UseCase3Description" xml:space="preserve"><value>Użyteczność w ofertach i kampaniach powiązanych z CloudCity.</value></data>
+  <data name="FaqTitle" xml:space="preserve"><value>FAQ</value></data>
+  <data name="Faq1Question" xml:space="preserve"><value>Czym jest CloudCity Coin?</value></data>
+  <data name="Faq1Answer" xml:space="preserve"><value>Cyfrowy aktyw płatniczy zaprojektowany do zastosowań w ekosystemie CloudCity.</value></data>
+  <data name="Faq2Question" xml:space="preserve"><value>Gdzie mogę go kupić?</value></data>
+  <data name="Faq2Answer" xml:space="preserve"><value>Na oficjalnej stronie Pump.fun podlinkowanej powyżej.</value></data>
+  <data name="Faq3Question" xml:space="preserve"><value>Czy potrzebuję Phantom?</value></data>
+  <data name="Faq3Answer" xml:space="preserve"><value>Potrzebujesz dowolnego portfela kompatybilnego z Solana; Phantom jest najpopularniejszy.</value></data>
+  <data name="FinalCtaTitle" xml:space="preserve"><value>Dołącz do ekosystemu CloudCity Coin</value></data>
+  <data name="FinalCtaDescription" xml:space="preserve"><value>Wejdź do premium środowiska cloud + crypto stworzonego dla płatności digital-first.</value></data>
+  <data name="RiskDisclaimer" xml:space="preserve"><value>Zastrzeżenie ryzyka: Aktywa cyfrowe są zmienne. Zawsze przeprowadź własny research przed zakupem.</value></data>
+  <data name="FinalPrimaryCta" xml:space="preserve"><value>Kup CloudCity Coin</value></data>
+  <data name="FinalSecondaryCta" xml:space="preserve"><value>Skontaktuj się z CloudCity</value></data>
+  <data name="SEOTitle" xml:space="preserve"><value>CloudCity Coin - CloudCityCenter</value></data>
+  <data name="SEODescription" xml:space="preserve"><value>CloudCity Coin to cyfrowy aktyw płatniczy w ekosystemie CloudCity, z użytecznością w wybranych usługach infrastrukturalnych i chmurowych.</value></data>
+  <data name="SEOKeywords" xml:space="preserve"><value>CloudCity Coin, krypto CloudCity, moneta Solana, chmurowy aktyw płatniczy</value></data>
+</root>


### PR DESCRIPTION
### Motivation

- Complete multilingual support for the CloudCity Coin page so the language switcher (Polish, French, German, Spanish) shows the page fully translated using the existing localization approach. 

### Description

- Added localized resource files `CloudCityCenter/Resources/Views/Coin/Index.pl.resx`, `Index.fr.resx`, `Index.de.resx`, and `Index.es.resx` containing translations for all keys referenced by the view and SEO metadata. 
- Preserved the existing localization key names and English base `Index.resx` to keep ASP.NET fallback behavior intact. 
- Only resource files were added; no layout, style, or view markup changes were made so page structure and UI remain unchanged. 

### Testing

- Verified the new resource files exist and contain the translated keys by inspecting `CloudCityCenter/Resources/Views/Coin/Index.*.resx` content. 
- Confirmed translations cover hero badge/title/subtitle/description, CTAs, section titles, cards, How-to-Buy steps, service cards, FAQs, disclaimer, final CTA, and SEO title/description/keywords. 
- Attempted `dotnet build CloudCityCenter/CloudCityCenter.csproj` but the environment lacks the .NET SDK (`dotnet: command not found`), so a local/project CI build is still recommended to validate compilation and runtime localization resolution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aecd07d3c832b8731be64dea5a6d9)